### PR TITLE
Request Processor healthcheck

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,7 +140,7 @@ jobs:
 
       - run: docker pull $DOCKER_REPO:${GITHUB_REF_NAME} || echo "no current latest image"
 
-      - run: docker build --build-arg DEPLOY_TIME="$(date +%Y-%m-%dT%H:%M:%S)" -t $DOCKER_REPO:${{ steps.vars.outputs.sha_short }} -f request-processor/Dockerfile .
+      - run: docker build --build-arg DEPLOY_TIME="$(date +%Y-%m-%dT%H:%M:%S)" --build-arg GIT_COMMIT="${{ steps.vars.outputs.sha_short }}" -t $DOCKER_REPO:${{ steps.vars.outputs.sha_short }} -f request-processor/Dockerfile .
 
       - run: docker tag $DOCKER_REPO:${{ steps.vars.outputs.sha_short }} $DOCKER_REPO:${GITHUB_REF_NAME}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     build:
       context: .
       dockerfile: request-processor/Dockerfile
+      args:
+        GIT_COMMIT: placeholder
     environment:
       PYTHONUNBUFFERED: 1
       AWS_ENDPOINT_URL: http://localstack:4566

--- a/request-processor/Dockerfile
+++ b/request-processor/Dockerfile
@@ -1,12 +1,15 @@
 FROM python:3.12-alpine
 
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+
 RUN apk add --no-cache musl-dev curl
 RUN pip3 install cython
 RUN apk add --no-cache libcurl curl-dev build-base git proj proj-dev proj-util geos-dev
 
 # Install GDAL dependencies
 RUN apk update && \
-    apk add --no-cache gdal-dev gdal gdal-tools aws-cli postgresql-client && \
+    apk add --no-cache gdal-dev gdal gdal-tools aws-cli postgresql-client jq && \
     rm -rf /var/cache/apk/*
 
 COPY request-processor/requirements/requirements.txt requirements/requirements.txt
@@ -15,12 +18,16 @@ COPY request-processor/makerules/makerules.mk makerules/makerules.mk
 COPY request-processor/makerules/python.mk makerules/python.mk
 RUN make init
 
+
+COPY .git/ .
 COPY request-processor/src/. .
 
 COPY ../request_model ./request_model
 COPY ../task_interface ./task_interface
 
 COPY request-processor/docker-healthcheck.sh docker-healthcheck.sh
+
+COPY request-processor/healthcheck-output-template.json healthcheck-output-template.json
 
 HEALTHCHECK CMD "./docker-healthcheck.sh"
 

--- a/request-processor/Dockerfile
+++ b/request-processor/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache libcurl curl-dev build-base git proj proj-dev proj-util g
 
 # Install GDAL dependencies
 RUN apk update && \
-    apk add --no-cache gdal-dev gdal gdal-tools && \
+    apk add --no-cache gdal-dev gdal gdal-tools aws-cli postgresql-client && \
     rm -rf /var/cache/apk/*
 
 COPY request-processor/requirements/requirements.txt requirements/requirements.txt
@@ -19,6 +19,10 @@ COPY request-processor/src/. .
 
 COPY ../request_model ./request_model
 COPY ../task_interface ./task_interface
+
+COPY request-processor/docker-healthcheck.sh docker-healthcheck.sh
+
+HEALTHCHECK CMD "./docker-healthcheck.sh"
 
 COPY request-processor/docker-entrypoint.sh docker-entrypoint.sh
 

--- a/request-processor/docker-healthcheck.sh
+++ b/request-processor/docker-healthcheck.sh
@@ -1,5 +1,30 @@
 # Checks health by checking worker process is running along with connectivity checks of SQS and Postgres
-set -e
-pgrep celery
-aws sqs get-queue-url --queue-name celery
-pg_isready -d "$DATABASE_URL"
+
+# Check Celery process is running
+pgrep celery > /dev/null 2> /dev/null
+exit_code=$?
+
+# Check SQS queue exists
+if aws sqs get-queue-url --queue-name celery > /dev/null 2> /dev/null
+then
+  sqs_status="HEALTHY"
+else
+  sqs_status="UNHEALTHY";
+  exit_code=1;
+fi
+
+# Check Postgres DB is ready
+if pg_isready -d "$DATABASE_URL" > /dev/null 2> /dev/null
+then
+  pg_status="HEALTHY"
+else
+  pg_status="UNHEALTHY";
+  exit_code=1;
+fi
+
+# Provide JSON output
+jq ".version=\"$GIT_COMMIT\"" healthcheck-output-template.json | jq ".dependencies[\"request-db\"].status=\"$pg_status\"" | jq ".dependencies.sqs.status=\"$sqs_status\""
+
+exit $exit_code
+
+# Note use of  > /dev/null 2> /dev/null which suppresses stout and stderr

--- a/request-processor/docker-healthcheck.sh
+++ b/request-processor/docker-healthcheck.sh
@@ -1,0 +1,5 @@
+# Checks health by checking worker process is running along with connectivity checks of SQS and Postgres
+set -e
+pgrep celery
+aws sqs get-queue-url --queue-name celery
+pg_isready -d "$DATABASE_URL"

--- a/request-processor/healthcheck-output-template.json
+++ b/request-processor/healthcheck-output-template.json
@@ -1,0 +1,12 @@
+{
+  "name": "request-processor",
+  "version": "PLACEHOLDER",
+  "dependencies": {
+    "request-db": {
+      "status": "PLACEHOLDER"
+    },
+    "sqs": {
+      "status": "PLACEHOLDER"
+    }
+  }
+}


### PR DESCRIPTION
Added docker-healthcheck bash script which can be used as part of the in-built HEALTHCHECK instruction in its Dockerfile and can be configured to run as part of the ECS service/task for the processor.

Example of running healthcheck locally via docker compose:

```
10:52 $ docker compose exec request-processor /bin/sh
/ # ./docker-healthcheck.sh
{
  "name": "request-processor",
  "version": "1fd7440",
  "dependencies": {
    "request-db": {
      "status": "HEALTHY"
    },
    "sqs": {
      "status": "HEALTHY"
    }
  }
}
/ # echo $?
0
```