### PR TITLE
Response Details jsonpath filter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: request_database
     restart: on-failure
+    ports:
+      - "54320:5432"
 
   request-processor:
     build:

--- a/request-api/src/crud.py
+++ b/request-api/src/crud.py
@@ -1,3 +1,4 @@
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from pagination_model import PaginatedResult, PaginationParams
@@ -9,10 +10,13 @@ def get_request(db: Session, request_id: int):
     return db.query(models.Request).filter(models.Request.id == request_id).first()
 
 
-def get_response_details(db: Session, request_id: int, pagination_params=PaginationParams()):
+def get_response_details(db: Session, request_id: int, jsonpath: str = None, pagination_params=PaginationParams()):
     base_query = (db.query(models.ResponseDetails)
                   .join(models.ResponseDetails.response)
                   .filter(models.Response.request_id == request_id))
+    if jsonpath is not None:
+        base_query = base_query.filter(func.jsonb_path_match(models.ResponseDetails.detail, jsonpath))
+
     response_details = base_query.offset(pagination_params.offset).limit(pagination_params.limit).all()
     return PaginatedResult(
         params=pagination_params,

--- a/request_model/models.py
+++ b/request_model/models.py
@@ -1,6 +1,7 @@
 import shortuuid
 from pydantic import BaseModel
-from sqlalchemy import Column, Integer, String, DateTime, JSON, func, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, func, ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -15,7 +16,7 @@ class Request(Base):
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
     status = Column(String)
-    params = Column(JSON)
+    params = Column(JSONB)
     type = Column(String)
 
     response = relationship("Response", uselist=False, back_populates="request", lazy='joined')
@@ -26,8 +27,8 @@ class Response(Base):
 
     id = Column(Integer, primary_key=True)
     request_id = Column(String, ForeignKey("request.id"))
-    data = Column(JSON)
-    error = Column(JSON)
+    data = Column(JSONB)
+    error = Column(JSONB)
 
     request = relationship("Request", back_populates="response")
     details = relationship("ResponseDetails", back_populates="response", uselist=True, lazy='noload')
@@ -38,7 +39,7 @@ class ResponseDetails(Base):
 
     id = Column(Integer, primary_key=True)
     response_id = Column(Integer, ForeignKey("response.id"))
-    detail = Column(JSON)
+    detail = Column(JSONB)
 
     response = relationship("Response", back_populates="details")
 


### PR DESCRIPTION
Added jsonpath filter to response details endpoint.  Enables Publish Service frontend to fetch pages of response details which have a specific severity level, i.e. error