### PR TITLE
Adding transformed csv to the response

### DIFF
--- a/request-processor/src/application/configs/mandatory_fields.yaml
+++ b/request-processor/src/application/configs/mandatory_fields.yaml
@@ -10,7 +10,6 @@ article-4-direction-area:
 - name
 - permitted-development-rights
 conservation-area:
-- reference
 - geometry
 - name
 conservation-area-document:

--- a/request-processor/src/application/configs/mapping.yaml
+++ b/request-processor/src/application/configs/mapping.yaml
@@ -134,6 +134,11 @@ mappings:
   description: Point must use WGS84, OSGB or Mercator coordinates
   summary-singular: "1 point must use WGS84, OSGB or Mercator coordinates"
   summary-plural: "{count} points must use WGS84, OSGB or Mercator coordinates"
+- field: GeoX,GeoY
+  issue-type: invalid coordinates
+  description: Geometry must use WGS84, OSGB or Mercator coordinates
+  summary-singular: "1 geometry must use WGS84, OSGB or Mercator coordinates"
+  summary-plural: "{count} geometries must use WGS84, OSGB or Mercator coordinates"
 - field: geometry
   issue-type: invalid geometry - not fixable
   description: Geometry must be correctly formatted

--- a/request-processor/src/application/core/workflow.py
+++ b/request-processor/src/application/core/workflow.py
@@ -90,6 +90,11 @@ def run_workflow(
                 directories.COLUMN_FIELD_DIR, dataset, request_id, f"{resource}.csv"
             )
         )
+        transformed_json = csv_to_json(
+            os.path.join(
+                directories.TRANSFORMED_DIR, dataset, request_id, f"{resource}.csv"
+            )
+        )
         updateColumnFieldLog(column_field_json, required_fields)
         summary_data = error_summary(
             issue_log_json, column_field_json, not_mapped_columns
@@ -100,6 +105,7 @@ def run_workflow(
             "issue-log": issue_log_json,
             "column-field-log": column_field_json,
             "error-summary": summary_data,
+            "transformed-csv": transformed_json,
         }
         # logger.info("Error Summary: %s", summary_data)
     except Exception as e:
@@ -200,7 +206,14 @@ def add_geom_mapping(dataset, pipeline_dir, geom_type, resource, pipeline_csv):
         new_mapping = {}
         for field in fieldnames:
             new_mapping.update({field: ""})
-        new_mapping.update({"dataset": "tree", "resource": resource, "column": "WKT", "field": "geometry"})
+        new_mapping.update(
+            {
+                "dataset": "tree",
+                "resource": resource,
+                "column": "WKT",
+                "field": "geometry",
+            }
+        )
         with open(os.path.join(pipeline_dir, pipeline_csv), "a") as csv_file:
             csv_file.write("\n")
             writer = csv.DictWriter(csv_file, fieldnames=fieldnames)

--- a/request-processor/tests/conftest.py
+++ b/request-processor/tests/conftest.py
@@ -152,7 +152,7 @@ def mock_extract_dataset_field_rows(mock_directories):
                 "field-dataset": "",
                 "guidance": "",
                 "hint": "",
-            }
+            },
         ]
         fieldnames = rows[0].keys()
         with open(mock_field_csv, "w") as f:

--- a/request-processor/tests/data/specification/dataset-schema.csv
+++ b/request-processor/tests/data/specification/dataset-schema.csv
@@ -1,3 +1,4 @@
 dataset,schema
 article-4-direction-area,article-4-direction-area
 tree,tree
+brownfield-land, Brownfield-land

--- a/request-processor/tests/data/specification/dataset.csv
+++ b/request-processor/tests/data/specification/dataset.csv
@@ -7,3 +7,11 @@ crown-copyright,tree-preservation-order,tree-preservation-orders,tree,An individ
 Each [tree preservation order](/dataset/tree-preservation-order) may apply to a number of [tree preservation order zones](/dataset/tree-preservation-order-zone), and a number of individual trees.
 
 This dataset contains data from [a small group of local planning authorities](/about/) who we are working with to develop a [data specification for tree preservation orders](https://www.digital-land.info/guidance/specifications/tree-preservation-order).",environment,geography,1.0,Q10884,Tree
+crown-copyright,brownfield-land,brownfield-land,brownfield-land,Land that has been previously been developed,,,28,site,1700000,1799999,ogl3,Brownfield land,"{ ""colour"": ""#745729"", ""type"": ""point"" }",Brownfield land,live,,dataset,,,"Local planning authorities designate sites in their area as being [brownfield land](https://www.gov.uk/guidance/brownfield-land-registers), and publish a register of brownfield sites annually following [GOV.UK guidance](https://www.gov.uk/government/publications/brownfield-land-registers-data-standard/publish-your-brownfield-land-data).
+
+Each site references the following categories:
+
+* [ownership-status](/dataset/ownership-status)
+* [planning-permission-status](/dataset/planning-permission-status)
+* [planning-permission-type](/dataset/planning-permission-type)
+* [site-category](/dataset/site-category)",development,geography,1.1,Q896586,Brownfield_land

--- a/request-processor/tests/integration/src/test_tasks.py
+++ b/request-processor/tests/integration/src/test_tasks.py
@@ -14,10 +14,17 @@ def test_data_dir(test_dir):
     return os.path.realpath(f"{test_dir}/../../data")
 
 
-@pytest.mark.parametrize("filename, uploaded_filename, expected_status",
-                         [("article-direction-area.csv", "492f15d8-45e4-427e-bde0-f60d69889f40", "COMPLETE"),
-                          ("invalid.csv", "invalid", "FAILED")]
-                         )
+@pytest.mark.parametrize(
+    "filename, uploaded_filename, expected_status",
+    [
+        (
+            "article-direction-area.csv",
+            "492f15d8-45e4-427e-bde0-f60d69889f40",
+            "COMPLETE",
+        ),
+        ("invalid.csv", "invalid", "FAILED"),
+    ],
+)
 def test_check_datafile(
     mocker,
     celery_app,
@@ -29,7 +36,7 @@ def test_check_datafile(
     test_data_dir,
     filename,
     uploaded_filename,
-    expected_status
+    expected_status,
 ):
     """
     This function tests the check_datafile task for file validation.
@@ -47,19 +54,27 @@ def test_check_datafile(
         uploaded_filename: Uploaded filename.
         expected_status: Expected status after validation.
     """
-    params = {"collection": "article-4-direction",
-              "dataset": "article-4-direction-area",
-              "original_filename": filename,
-              "uploaded_filename": uploaded_filename}
-    request = _create_request(schemas.CheckFileParams(**params), schemas.RequestTypeEnum.check_file)
-    _handle_pipeline_config_csvs(test_data_dir, mock_directories, mocker, mock_fetch_pipeline_csvs, request)
+    params = {
+        "collection": "article-4-direction",
+        "dataset": "article-4-direction-area",
+        "original_filename": filename,
+        "uploaded_filename": uploaded_filename,
+    }
+    request = _create_request(
+        schemas.CheckFileParams(**params), schemas.RequestTypeEnum.check_file
+    )
+    _handle_pipeline_config_csvs(
+        test_data_dir, mock_directories, mocker, mock_fetch_pipeline_csvs, request
+    )
 
     # Convert mock directory paths to strings
     mock_directories_str = {
         key: str(path) for key, path in mock_directories._asdict().items()
     }
 
-    _register_and_check_request(mock_directories_str, celery_app, request, expected_status)
+    _register_and_check_request(
+        mock_directories_str, celery_app, request, expected_status
+    )
 
 
 @pytest.mark.parametrize(
@@ -68,8 +83,12 @@ def test_check_datafile(
         (
             "valid_url",
             "exampleurl.csv",
-            (None,
-             '{"type":"FeatureCollection","properties":{"exceededTransferLimit":true}, "features":[{"type":"Feature","id":1,"geometry":{"type":"Point", "coordinates":[-1.59153574212325,54.9392094142866]}, "properties": {"reference": "CA01","name": "Ashleworth Conservation Area"}}]}'.encode("utf-8")),
+            (
+                None,
+                '{"type":"FeatureCollection","properties":{"exceededTransferLimit":true}, "features":[{"type":"Feature","id":1,"geometry":{"type":"Point", "coordinates":[-1.59153574212325,54.9392094142866]}, "properties": {"reference": "CA01","name": "Ashleworth Conservation Area"}}]}'.encode(  # noqa
+                    "utf-8"
+                ),
+            ),
             "COMPLETE",
             True,
         ),
@@ -116,12 +135,18 @@ def test_check_datafile_url(
         mock_response: determine if mock fetch_pipeline_csvs should be called.
     """
 
-    params = {"collection": "article-4-direction",
-              "dataset": "article-4-direction-area",
-              "url": url}
-    request = _create_request(schemas.CheckUrlParams(**params), schemas.RequestTypeEnum.check_url)
+    params = {
+        "collection": "article-4-direction",
+        "dataset": "article-4-direction-area",
+        "url": url,
+    }
+    request = _create_request(
+        schemas.CheckUrlParams(**params), schemas.RequestTypeEnum.check_url
+    )
 
-    _handle_pipeline_config_csvs(test_data_dir, mock_directories, mocker, mock_fetch_pipeline_csvs, request)
+    _handle_pipeline_config_csvs(
+        test_data_dir, mock_directories, mocker, mock_fetch_pipeline_csvs, request
+    )
 
     mock_directories_str = {
         key: str(path) for key, path in mock_directories._asdict().items()
@@ -131,7 +156,9 @@ def test_check_datafile_url(
         "application.core.utils.get_request", return_value=get_request_return_value
     )
 
-    _register_and_check_request(mock_directories_str, celery_app, request, expected_status)
+    _register_and_check_request(
+        mock_directories_str, celery_app, request, expected_status
+    )
 
 
 def _wait_for_request_status(
@@ -183,7 +210,9 @@ def _create_request(params, type):
     return request
 
 
-def _handle_pipeline_config_csvs(test_data_dir, mock_directories, mocker, mock_fetch_pipeline_csvs, request):
+def _handle_pipeline_config_csvs(
+    test_data_dir, mock_directories, mocker, mock_fetch_pipeline_csvs, request
+):
     source_organisation_csv = f"{test_data_dir}/csvs/organisation.csv"
     destination_organisation_csv = os.path.join(
         mock_directories.CACHE_DIR, "organisation.csv"
@@ -195,7 +224,9 @@ def _handle_pipeline_config_csvs(test_data_dir, mock_directories, mocker, mock_f
     )
 
 
-def _register_and_check_request(mock_directories_str, celery_app, request, expected_status):
+def _register_and_check_request(
+    mock_directories_str, celery_app, request, expected_status
+):
     mock_directories_json = json.dumps(mock_directories_str)
     check_datafile_task = celery_app.register_task(check_datafile)
     check_datafile_task.delay(request.model_dump(), directories=mock_directories_json)

--- a/request-processor/tests/unit/src/application/core/test_workflow.py
+++ b/request-processor/tests/unit/src/application/core/test_workflow.py
@@ -125,7 +125,7 @@ def test_error_summary():
     assert any(internal_issue not in message for message in json_data)
 
 
-def test_csv_to_json_with_valid_file(mocker, test_dir):
+def test_csv_to_json_with_valid_file(test_dir):
     # Prepare a CSV file
     row1 = {
         "dataset": "conservation-area",

--- a/request-processor/tests/unit/src/test_tasks.py
+++ b/request-processor/tests/unit/src/test_tasks.py
@@ -20,6 +20,10 @@ from request_model import models, schemas
             {
                 "column-field-log": {},
                 "error-summary": {},
+                "transformed-csv": [
+                    {"column1": "value1", "column2": "value2-transformed"},
+                    {"column1": "value3", "column2": "value4"},
+                ],
                 "converted-csv": [
                     {"column1": "value1", "column2": "value2"},
                     {"column1": "value3", "column2": "value4"},
@@ -79,7 +83,11 @@ def test_save_response_to_db(
             .first()
         )
         assert response_query is not None, "Response table should contain data"
-        data = response_query.data if test_name == "success_check_file" else response_query.error
+        data = (
+            response_query.data
+            if test_name == "success_check_file"
+            else response_query.error
+        )
 
         for key in expected_keys:
             assert key in data, f"{key} should be present in data"
@@ -91,8 +99,13 @@ def test_save_response_to_db(
                 .filter_by(response_id=response_query.id)
                 .first()
             )
-            assert (response_details_query is not None), "ResponseDetails table should contain details"
+            assert (
+                response_details_query is not None
+            ), "ResponseDetails table should contain details"
             detail = response_details_query.detail
             assert "converted_row" in detail, "converted_row should be present in data"
             assert "issue_logs" in detail, "issue_logs should be present in data"
             assert "entry_number" in detail, "entry_number should be present in data"
+            assert (
+                "transformed_row" in detail
+            ), "transformed_row should be present in data"


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This update adds the transformed CSV file to the response in the async backend. The Providers team requested this specifically for the brownfield land collection, where geometry is provided in geoX and geoY formats. To display these points on the UI, we need to include either a point or geometry, as is done for all other collections. In the transformed resource, we convert the geoX and geoY values into a point, making it easier to display the data accurately on the map.

## Related Tickets & Documents

https://trello.com/c/HsnP6iJg/3482-send-transformed-file-to-check-service-frontend


## QA Instructions, Screenshots, Recordings

This functionality will need to be tested by the Providers team through the check service after they implement this. In the meantime, it can be tested using Postman. You can verify the transformed-csv in the response and ensure that the data is displayed correctly, corresponding to the entry-number

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

