### PR TITLE
feat: add optional metadata fields to requesr schema

### DIFF
--- a/aws-example-sqs/test/test_message_wrapper.py
+++ b/aws-example-sqs/test/test_message_wrapper.py
@@ -98,9 +98,11 @@ def test_send_messages_wrong_size(make_stubber, make_queue, count):
     sqs_stubber.stub_send_message_batch(
         queue.url,
         messages,
-        "AWS.SimpleQueueService.EmptyBatchRequest"
-        if count == 0
-        else "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+        (
+            "AWS.SimpleQueueService.EmptyBatchRequest"
+            if count == 0
+            else "AWS.SimpleQueueService.TooManyEntriesInBatchRequest"
+        ),
     )
 
     with pytest.raises(ClientError) as exc_info:

--- a/performance-test/locustfile.py
+++ b/performance-test/locustfile.py
@@ -13,20 +13,22 @@ class PlatformServiceUser(HttpUser):
                 "collection": "article_4_direction",
                 "dataset": "article_4_direction_area",
                 "original_filename": "bogdan-farca-CEx86maLUSc-unsplash.jpg",
-                "uploaded_filename": "B1E16917-449C-4FC5-96D1-EE4255A79FB1"
+                "uploaded_filename": "B1E16917-449C-4FC5-96D1-EE4255A79FB1",
             }
         }
         creation_response = self.client.post("/requests", json=create_request)
-        request_id = creation_response.json()['id']
+        request_id = creation_response.json()["id"]
 
         def _wait_for_request_status(
-                expected_status, timeout_seconds=30, interval_seconds=1
+            expected_status, timeout_seconds=30, interval_seconds=1
         ):
             seconds_waited = 0
             actual_status = "UNKNOWN"
             while seconds_waited <= timeout_seconds:
-                response = self.client.get(f"/requests/{request_id}", name="/requests/{id}")
-                if response.json()['status'] == expected_status:
+                response = self.client.get(
+                    f"/requests/{request_id}", name="/requests/{id}"
+                )
+                if response.json()["status"] == expected_status:
                     return
                 else:
                     time.sleep(interval_seconds)
@@ -35,4 +37,5 @@ class PlatformServiceUser(HttpUser):
                         f"Waiting {interval_seconds} second(s) for expected status of "
                         f"{expected_status} on request {request_id}"
                     )
-        _wait_for_request_status('COMPLETE')
+
+        _wait_for_request_status("COMPLETE")

--- a/request-api/migrations/versions/d45c986e2727_create_indexes_for_foreign_keys.py
+++ b/request-api/migrations/versions/d45c986e2727_create_indexes_for_foreign_keys.py
@@ -5,6 +5,7 @@ Revises: 287b3ab94dec
 Create Date: 2024-05-16 07:38:06.028489
 
 """
+
 from alembic import op
 
 

--- a/request-api/tests/integration/test_main.py
+++ b/request-api/tests/integration/test_main.py
@@ -116,9 +116,9 @@ def test_get_db_fails_after_retries(mock_restored, mock_slack, mock_session_make
 @patch("main.WebClient")
 @patch(
     "main.os.environ.get",
-    side_effect=lambda k, d=None: "fake_token"
-    if k == "SLACK_BOT_TOKEN"
-    else "fake_channel",
+    side_effect=lambda k, d=None: (
+        "fake_token" if k == "SLACK_BOT_TOKEN" else "fake_channel"
+    ),
 )
 def test_send_slack_alert(mock_env, mock_webclient):
     mock_client_instance = mock_webclient.return_value

--- a/request-processor/src/application/core/utils.py
+++ b/request-processor/src/application/core/utils.py
@@ -35,9 +35,9 @@ def get_request(url, verify_ssl=True):
             if not response.headers.get("Content-Type", "").startswith("text/html"):
                 content = response.content
             else:
-                log[
-                    "message"
-                ] = "The requested URL leads to a html webpage which we cannot process"
+                log["message"] = (
+                    "The requested URL leads to a html webpage which we cannot process"
+                )
         else:
             log["message"] = (
                 "The requested URL could not be downloaded: " + log["status"] + " error"

--- a/request-processor/src/tasks.py
+++ b/request-processor/src/tasks.py
@@ -55,9 +55,9 @@ def check_datafile(request: Dict, directories=None):
                     fileName = utils.save_content(content, tmp_dir)
                 else:
                     log = {}
-                    log[
-                        "message"
-                    ] = "Endpoint URL includes multiple dataset layers. Endpoint URL must include a single dataset layer only."  # noqa
+                    log["message"] = (
+                        "Endpoint URL includes multiple dataset layers. Endpoint URL must include a single dataset layer only."  # noqa
+                    )
                     log["status"] = ""
                     log["exception_type"] = "URL check failed"
                     save_response_to_db(request_schema.id, log)

--- a/request_model/schemas.py
+++ b/request_model/schemas.py
@@ -80,4 +80,3 @@ class Request(RequestBase):
     response: Optional[ResponseModel]
 
     model_config = ConfigDict(from_attributes=True)
- 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds three optional metadata fields to the request params:
documentation_url (URL)
licence (string)
start_date (date, YYYY-MM-DD)
## Related Tickets & Documents

## Summary of changes
**schemas.py**: extended Params with documentation_url: Optional[AnyHttpUrl], licence: Optional[str], start_date: Optional[date].
**main.py:** wired schema into request creation/validation so these fields can be accepted on POST; responses now include these params.
No database migration required (params stored as JSON).


This supports the “Optional Inputs” flow in the UI: if these are missing after checks, the UI can prompt the user to provide them and PATCH the request.

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.

[- Ticket Link]
https://github.com/digital-land/config/issues/847
https://github.com/digital-land/config/issues/1024)

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

OpenAPI docs at http://localhost:8000/docs.


Steps
POST create a request with optional fields:
In Swagger, call POST /requests with a params payload that includes documentation_url, licence, and start_date.

example : 
```
{
  "params": {
     "type": "check_url",
     "collection": "brownfield-land",
     "dataset": "brownfield-land",
     "url": "http://info.ambervalley.gov.uk/shareddatasets/brownfieldlandregister/AmberValleyBrownfieldLandRegister2020.csv",
     "documentation_url": "https://government.gov.uk",
     "licence": "ogl",
     "start_date": "2025-08-10"
  }
}
```
✅ Expect: 202 Accepted / 200 Created (depending on your API), and GET /requests/{id} returns these fields under params.
POST create a request without optional fields:
In Swagger, call POST /requests with params that omit the three fields.
✅ Expect: request is created; GET /requests/{id} shows them as absent. (UI will later prompt for them.)
PATCH update optional fields (if PATCH is already implemented in this repo):
Call PATCH /requests/{id} with body:
✅ Expect: fields are merged into existing params (no other params overwritten), and GET /requests/{id} reflects changes.

`jsonCopyEdit{"params": {"documentation_url": "https://example.org/docs","licence": "OGL-3.0","start_date": "2025-08-09"} } `

