### PR TITLE
Wrapper for URL's with commas

### DIFF
--- a/request-processor/src/application/core/utils.py
+++ b/request-processor/src/application/core/utils.py
@@ -396,7 +396,9 @@ def validate_source(
     if not documentation_url:
         logger.warning("No documentation URL provided")
 
-    safe_documentation_url = _quote_url_if_comma(documentation_url) if documentation_url else ""
+    safe_documentation_url = (
+        _quote_url_if_comma(documentation_url) if documentation_url else ""
+    )
 
     if not start_date:
         start_date = datetime.now().strftime("%Y-%m-%d")

--- a/request-processor/src/application/core/utils.py
+++ b/request-processor/src/application/core/utils.py
@@ -10,6 +10,13 @@ from datetime import datetime
 logger = get_logger(__name__)
 
 
+def _quote_url_if_comma(url):
+    """Wrap url in double quotes if it contains a comma, to prevent CSV parsing errors."""
+    if url and "," in url:
+        return f'"{url}"'
+    return url
+
+
 def get_request(url, verify_ssl=True):
     # log["ssl-verify"] = verify_ssl
     log = {"status": "", "message": ""}
@@ -315,6 +322,8 @@ def validate_endpoint(url, config_dir, plugin, start_date=None):
                 ]
             )
 
+    safe_url = _quote_url_if_comma(url)
+
     endpoint_exists = False
     existing_entry = None
 
@@ -322,7 +331,7 @@ def validate_endpoint(url, config_dir, plugin, start_date=None):
         with open(endpoint_csv_path, "r", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                if row.get("endpoint-url", "").strip() == url.strip():
+                if row.get("endpoint-url", "").strip() == safe_url.strip():
                     endpoint_exists = True
                     existing_entry = {
                         "endpoint": row.get("endpoint", ""),
@@ -350,7 +359,7 @@ def validate_endpoint(url, config_dir, plugin, start_date=None):
 
         endpoint_key, new_endpoint_row = append_endpoint(
             endpoint_csv_path=endpoint_csv_path,
-            endpoint_url=url,
+            endpoint_url=safe_url,
             entry_date=entry_date,
             start_date=start_date,
             end_date="",
@@ -387,6 +396,8 @@ def validate_source(
     if not documentation_url:
         logger.warning("No documentation URL provided")
 
+    safe_documentation_url = _quote_url_if_comma(documentation_url) if documentation_url else ""
+
     if not start_date:
         start_date = datetime.now().strftime("%Y-%m-%d")
     entry_date = datetime.now().isoformat()
@@ -397,7 +408,7 @@ def validate_source(
         organisation=organisation,
         endpoint_key=endpoint_key,
         attribution="",
-        documentation_url=documentation_url or "",
+        documentation_url=safe_documentation_url,
         licence=licence or "",
         pipelines=dataset,
         entry_date=entry_date,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

any URL containing a comma (e.g. https://example.com/data?fields=a,b) will be stored as "https://example.com/data?fields=a,b" in the CSV, preventing the comma from being misinterpreted as a field separator by downstream CSV consumers.


