### PR TITLE
97 listed building file throttles service

### DIFF
--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -198,6 +198,7 @@ def fetch_add_data_response(
     specification_dir,
     cache_dir,
     endpoint,
+    converted_path=None,
 ):
     try:
         specification = Specification(specification_dir)
@@ -231,6 +232,7 @@ def fetch_add_data_response(
                     valid_category_values=valid_category_values,
                     disable_lookups=False,
                     endpoints=[endpoint],
+                    converted_path=converted_path,
                 )
 
                 existing_entities.extend(
@@ -284,6 +286,7 @@ def fetch_add_data_response(
                         valid_category_values=valid_category_values,
                         disable_lookups=False,
                         endpoints=[endpoint],
+                        converted_path=converted_path,
                     )
                 else:
                     logger.info(f"No unidentified lookups found in {resource_file}")

--- a/request-processor/src/application/core/workflow.py
+++ b/request-processor/src/application/core/workflow.py
@@ -465,8 +465,12 @@ def add_data_workflow(
         input_dir = os.path.join(directories.COLLECTION_DIR, "resource", request_id)
         collection_dir = os.path.join(directories.COLLECTION_DIR, request_id)
         output_path = os.path.join(directories.TRANSFORMED_DIR, request_id, file_name)
+        converted_path = Path(
+            os.path.join(directories.CONVERTED_DIR, request_id, f"{file_name}.csv")
+        )
         if not os.path.exists(output_path):
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        os.makedirs(converted_path.parent, exist_ok=True)
 
         resource = resource_from_path(os.path.join(input_dir, file_name))
         endpoint_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()
@@ -505,6 +509,7 @@ def add_data_workflow(
             specification_dir=directories.SPECIFICATION_DIR,
             cache_dir=directories.CACHE_DIR,
             endpoint=endpoint_hash,
+            converted_path=converted_path,
         )
 
         # Create endpoint and source summaries in workflow
@@ -531,6 +536,9 @@ def add_data_workflow(
             "pipeline-issues": pipeline_issues,
             "endpoint-summary": endpoint_summary,
             "source-summary": source_summary,
+            "converted-csv": csv_to_json(str(converted_path))
+            if converted_path.exists()
+            else csv_to_json(os.path.join(input_dir, file_name)),
             "transformed-csv": csv_to_json(output_path),
         }
 
@@ -548,6 +556,8 @@ def add_data_workflow(
             os.path.join(directories.COLLECTION_DIR, "resource", request_id),
             os.path.join(directories.COLLECTION_DIR, request_id),
             directories.COLLECTION_DIR,
+            os.path.join(directories.CONVERTED_DIR, request_id),
+            directories.CONVERTED_DIR,
             os.path.join(directories.TRANSFORMED_DIR, request_id),
             directories.TRANSFORMED_DIR,
             os.path.join(directories.PIPELINE_DIR, collection),

--- a/request-processor/src/celeryconfig.py
+++ b/request-processor/src/celeryconfig.py
@@ -3,14 +3,17 @@ import os
 broker_transport_options = {
     "region": os.environ["CELERY_BROKER_REGION"],
     "is_secure": os.environ.get("CELERY_BROKER_IS_SECURE", "false").lower() == "true",
-    # Wait time before allowing a message to be read again. Our default is 60 seconds (1 minute).
-    # Celery default is 1800 seconds (30 minutes)
+    # Must be >= task_time_limit so SQS doesn't re-deliver a message mid-execution.
     "visibility_timeout": int(
-        os.environ.get("CELERY_BROKER_VISIBILITY_TIMEOUT", "900")
+        os.environ.get("CELERY_BROKER_VISIBILITY_TIMEOUT", "1800")
     ),
 }
 
 broker_connection_retry_on_startup = True
+
+# Raise SoftTimeLimitExceeded at 29 min to allow graceful cleanup, hard kill at 30 min.
+task_soft_time_limit = 1740
+task_time_limit = 1800
 
 # Late ack means the task messages will be acknowledged __after__ the task has been executed,
 # not right before, which is the default behavior.

--- a/request-processor/src/celeryconfig.py
+++ b/request-processor/src/celeryconfig.py
@@ -3,9 +3,9 @@ import os
 broker_transport_options = {
     "region": os.environ["CELERY_BROKER_REGION"],
     "is_secure": os.environ.get("CELERY_BROKER_IS_SECURE", "false").lower() == "true",
-    # Must be >= task_time_limit so SQS doesn't re-deliver a message mid-execution.
+    # Must exceed task_time_limit (1800) so SQS doesn't re-deliver a message mid-execution.
     "visibility_timeout": int(
-        os.environ.get("CELERY_BROKER_VISIBILITY_TIMEOUT", "1800")
+        os.environ.get("CELERY_BROKER_VISIBILITY_TIMEOUT", "2100")
     ),
 }
 

--- a/request-processor/src/tasks.py
+++ b/request-processor/src/tasks.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from digital_land.collect import Collector, FetchStatus
 
 logger = get_task_logger(__name__)
+_DETAIL_BATCH_SIZE = 1000
 # Threshold for s3_transfer_manager to automatically use multipart download
 max_file_size_mb = 30
 
@@ -406,13 +407,40 @@ def _get_response(request_id):
     return result
 
 
-def save_response_to_db(request_id, response_data):  # noqa
-    """Currently handles three types of response_data:
-    1. Full check data workflow response with 'converted-csv', 'issue-log', etc.
-    2. Full add data workflow pipeline summary response with 'pipeline-summary'.
-    3. Error log with 'message'.
-    Saves appropriately to Response and ResponseDetails tables.
-    """
+def _save_response_details(
+    session, response_id, converted_row_data, issue_log_data, transformed_data
+):
+    issue_log_by_entry = {}
+    for issue in issue_log_data:
+        key = issue.get("entry-number")
+        issue_log_by_entry.setdefault(key, []).append(issue)
+
+    transformed_by_entry = {}
+    for row in transformed_data:
+        key = row.get("entry-number")
+        transformed_by_entry.setdefault(key, []).append(row)
+
+    for entry_number, converted_row in enumerate(converted_row_data, start=1):
+        entry_key = str(entry_number)
+        session.add(
+            models.ResponseDetails(
+                response_id=response_id,
+                detail={
+                    "converted_row": converted_row,
+                    "issue_logs": issue_log_by_entry.get(entry_key, []),
+                    "entry_number": entry_number,
+                    "transformed_row": transformed_by_entry.get(entry_key, []),
+                },
+            )
+        )
+        if entry_number % _DETAIL_BATCH_SIZE == 0:
+            session.flush()
+            session.expunge_all()
+
+    session.commit()
+
+
+def save_response_to_db(request_id, response_data):
     logger.info(f"save_response_to_db started for request_id: {request_id}")
     db_session = database.session_maker()
     with db_session() as session:
@@ -431,46 +459,16 @@ def save_response_to_db(request_id, response_data):  # noqa
                         "error-summary": response_data.get("error-summary", {}),
                         "plugin": response_data.get("plugin", None),
                     }
-                    # Create a new Response instance
                     new_response = models.Response(request_id=request_id, data=data)
-
-                    # Add the response to the session
                     session.add(new_response)
-                    session.flush()  # Flush to get the response ID
-
-                    entry_number = 1
-                    converted_row_data = response_data.get("converted-csv")
-                    issue_log_data = response_data.get("issue-log")
-                    transformed_data = response_data.get("transformed-csv")
-
-                    issue_log_by_entry = {}
-                    for issue in issue_log_data:
-                        key = issue.get("entry-number")
-                        issue_log_by_entry.setdefault(key, []).append(issue)
-
-                    transformed_by_entry = {}
-                    for row in transformed_data:
-                        key = row.get("entry-number")
-                        transformed_by_entry.setdefault(key, []).append(row)
-
-                    for converted_row in converted_row_data:
-                        entry_key = str(entry_number)
-                        new_response_detail = models.ResponseDetails(
-                            response_id=new_response.id,
-                            detail={
-                                "converted_row": converted_row,
-                                "issue_logs": issue_log_by_entry.get(entry_key, []),
-                                "entry_number": entry_number,
-                                "transformed_row": transformed_by_entry.get(
-                                    entry_key, []
-                                ),
-                            },
-                        )
-                        session.add(new_response_detail)
-                        entry_number += 1
-
-                    # Commit the changes to the database
-                    session.commit()
+                    session.flush()
+                    _save_response_details(
+                        session,
+                        new_response.id,
+                        response_data.get("converted-csv"),
+                        response_data.get("issue-log"),
+                        response_data.get("transformed-csv"),
+                    )
 
                 elif "pipeline-summary" in response_data:
                     data = {
@@ -481,40 +479,26 @@ def save_response_to_db(request_id, response_data):  # noqa
                     new_response = models.Response(request_id=request_id, data=data)
                     session.add(new_response)
                     session.flush()
-
-                    issue_log_data = response_data.get("pipeline-issues", [])
-
-                    for entry_number, transformed_row in enumerate(
-                        response_data.get("transformed-csv", []), start=1
-                    ):
-                        current_issue_logs = [
-                            issue
-                            for issue in issue_log_data
-                            if str(issue.get("entry-number")) == str(entry_number)
-                        ]
-                        new_response_detail = models.ResponseDetails(
-                            response_id=new_response.id,
-                            detail={
-                                "transformed_row": transformed_row,
-                                "issue_logs": current_issue_logs,
-                                "entry_number": entry_number,
-                            },
-                        )
-                        session.add(new_response_detail)
-
-                    session.commit()
+                    _save_response_details(
+                        session,
+                        new_response.id,
+                        response_data.get("converted-csv", []),
+                        response_data.get("pipeline-issues", []),
+                        response_data.get("transformed-csv", []),
+                    )
 
                 elif "message" in response_data:
                     error = CustomException(response_data)
-                    # error_detail_json = json.dumps(error.detail)
-                    # error_details = {
-                    #     "detail": error.as_dict()
-                    # }
                     new_response = models.Response(
                         request_id=request_id, error=error.detail
                     )
                     session.add(new_response)
                     session.commit()
+
+                else:
+                    logger.warning(
+                        f"save_response_to_db: unrecognised response shape for request_id: {request_id}"
+                    )
             else:
                 logger.info(f"Response already exists in DB for request: {request_id}")
         except Exception as e:

--- a/request-processor/src/tasks.py
+++ b/request-processor/src/tasks.py
@@ -406,7 +406,7 @@ def _get_response(request_id):
     return result
 
 
-def save_response_to_db(request_id, response_data):
+def save_response_to_db(request_id, response_data):  # noqa
     """Currently handles three types of response_data:
     1. Full check data workflow response with 'converted-csv', 'issue-log', etc.
     2. Full add data workflow pipeline summary response with 'pipeline-summary'.

--- a/request-processor/src/tasks.py
+++ b/request-processor/src/tasks.py
@@ -438,40 +438,36 @@ def save_response_to_db(request_id, response_data):
                     session.add(new_response)
                     session.flush()  # Flush to get the response ID
 
-                    # Initialize line number
                     entry_number = 1
                     converted_row_data = response_data.get("converted-csv")
                     issue_log_data = response_data.get("issue-log")
                     transformed_data = response_data.get("transformed-csv")
-                    # Save converted_row_data and issue_log_data in ResponseDetails
-                    for converted_row in converted_row_data:
-                        # Collect issue logs corresponding to the current line number
-                        current_issue_logs = [
-                            issue_log
-                            for issue_log in issue_log_data
-                            if issue_log.get("entry-number") == str(entry_number)
-                        ]
-                        transformed_csv = [
-                            transformed
-                            for transformed in transformed_data
-                            if transformed.get("entry-number") == str(entry_number)
-                        ]
 
+                    issue_log_by_entry = {}
+                    for issue in issue_log_data:
+                        key = issue.get("entry-number")
+                        issue_log_by_entry.setdefault(key, []).append(issue)
+
+                    transformed_by_entry = {}
+                    for row in transformed_data:
+                        key = row.get("entry-number")
+                        transformed_by_entry.setdefault(key, []).append(row)
+
+                    for converted_row in converted_row_data:
+                        entry_key = str(entry_number)
                         new_response_detail = models.ResponseDetails(
                             response_id=new_response.id,
                             detail={
                                 "converted_row": converted_row,
-                                "issue_logs": current_issue_logs,
+                                "issue_logs": issue_log_by_entry.get(entry_key, []),
                                 "entry_number": entry_number,
-                                "transformed_row": transformed_csv,
+                                "transformed_row": transformed_by_entry.get(
+                                    entry_key, []
+                                ),
                             },
                         )
                         session.add(new_response_detail)
-
-                        # Increment line number for the next iteration
                         entry_number += 1
-
-                        session.add(new_response_detail)
 
                     # Commit the changes to the database
                     session.commit()

--- a/request-processor/tests/unit/src/application/core/test_workflow.py
+++ b/request-processor/tests/unit/src/application/core/test_workflow.py
@@ -322,6 +322,7 @@ def test_add_data_workflow(monkeypatch):
     class DummyDirectories:
         PIPELINE_DIR = "/tmp/pipeline"
         COLLECTION_DIR = "/tmp/collection"
+        CONVERTED_DIR = "/tmp/converted"
         TRANSFORMED_DIR = "/tmp/transformed"
         SPECIFICATION_DIR = "/tmp/specification"
         CACHE_DIR = "/tmp/cache"
@@ -334,6 +335,7 @@ def test_add_data_workflow(monkeypatch):
         "pipeline-issues": [],
         "endpoint-summary": {"endpoint_summary": "mocked"},
         "source-summary": {"source_summary": "mocked"},
+        "converted-csv": [],
         "transformed-csv": [],
     }
 
@@ -387,6 +389,7 @@ def test_add_data_workflow_calls(monkeypatch):
     class DummyDirectories:
         PIPELINE_DIR = "/tmp/pipeline"
         COLLECTION_DIR = "/tmp/collection"
+        CONVERTED_DIR = "/tmp/converted"
         TRANSFORMED_DIR = "/tmp/transformed"
         SPECIFICATION_DIR = "/tmp/specification"
         CACHE_DIR = "/tmp/cache"
@@ -412,6 +415,7 @@ def test_add_data_workflow_calls(monkeypatch):
         specification_dir,
         cache_dir,
         endpoint,
+        converted_path=None,
     ):
         called["fetch_add_data_response"] = {
             "dataset": dataset,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Started as a ticket to address tasks failing in Async incorrectly, fix addresses both better failure and fixes the underlining bug.

So three things added here:
1. Celery will kill a task that takes more than 30 minutes.
2. Refactor of how response-details is created, it was quite inefficient beforehand at O(n^2) beforehand.
3. Converted CSV added to add-data tasks, with the entry number then used as an anchor to each transformed, issue, convert item in the json response list.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=161683827&issue=digital-land%7Casync-request-backend%7C97
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

When accessing endpoint /response-details, data should look identical.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: Mainly a code refactor
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented converted CSV file output support in request workflows

* **Performance & Reliability**
  * Extended request processing timeout from 15 to 30 minutes
  * Optimised database operations for response detail persistence
  * Enhanced temporary file cleanup during request processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->