### PR TITLE
detect if pipelines_append_required required in source csv

### DIFF
--- a/docs/add-data-response.schema.json
+++ b/docs/add-data-response.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/07/schema",
+  "title": "Add Data API Response",
+  "type": "object",
+  "required": ["id", "type", "status", "created", "modified", "response"],
+  "properties": {
+    "id": { "type": "string" },
+    "type": { "type": "string", "const": "add_data" },
+    "status": { "type": "string", "enum": ["PENDING", "PROCESSING", "COMPLETE", "FAILED"] },
+    "created": { "type": "string", "format": "date-time" },
+    "modified": { "type": "string", "format": "date-time" },
+    "response": {
+      "type": "object",
+      "properties": {
+        "error": { "type": ["object", "null"] },
+        "data": {
+          "type": ["object", "null"],
+          "properties": {
+            "plugin": { "type": ["string", "null"] },
+            "endpoint-summary": { "$ref": "#/$defs/endpointSummary" },
+            "source-summary": { "$ref": "#/$defs/sourceSummary" },
+            "pipeline-summary": { "$ref": "#/$defs/pipelineSummary" }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "endpointSummary": {
+      "type": "object",
+      "required": ["endpoint_url_in_endpoint_csv"],
+      "properties": {
+        "endpoint_url_in_endpoint_csv": { "type": "boolean" },
+        "new_endpoint_entry": {
+          "description": "Present when endpoint_url_in_endpoint_csv is false — a new row was appended to endpoint.csv",
+          "type": "object",
+          "properties": {
+            "endpoint": { "type": "string" },
+            "endpoint-url": { "type": "string" },
+            "entry-date": { "type": "string" },
+            "start-date": { "type": "string" },
+            "end-date": { "type": "string" },
+            "plugin": { "type": "string" },
+            "parameters": { "type": "string" }
+          }
+        },
+        "existing_endpoint_entry": {
+          "description": "Present when endpoint_url_in_endpoint_csv is true — the endpoint already exists in endpoint.csv",
+          "type": "object",
+          "properties": {
+            "endpoint": { "type": "string" },
+            "endpoint-url": { "type": "string" },
+            "entry-date": { "type": "string" },
+            "start-date": { "type": "string" },
+            "end-date": { "type": "string" },
+            "plugin": { "type": "string" },
+            "parameters": { "type": "string" }
+          }
+        }
+      }
+    },
+    "sourceSummary": {
+      "type": "object",
+      "required": ["documentation_url_in_source_csv"],
+      "properties": {
+        "documentation_url_in_source_csv": { "type": "boolean" },
+        "new_source_entry": {
+          "description": "Present when documentation_url_in_source_csv is false — a new row was appended to source.csv",
+          "type": "object",
+          "properties": {
+            "source": { "type": "string" },
+            "collection": { "type": "string" },
+            "organisation": { "type": "string" },
+            "endpoint": { "type": "string" },
+            "pipelines": { "type": "string" },
+            "documentation-url": { "type": "string" },
+            "licence": { "type": "string" },
+            "attribution": { "type": "string" },
+            "entry-date": { "type": "string" },
+            "start-date": { "type": "string" },
+            "end-date": { "type": "string" }
+          }
+        },
+        "existing_source_entry": {
+          "description": "Present when documentation_url_in_source_csv is true — the source already exists in source.csv",
+          "type": "object",
+          "properties": {
+            "source": { "type": "string" },
+            "collection": { "type": "string" },
+            "organisation": { "type": "string" },
+            "endpoint": { "type": "string" },
+            "pipelines": { "type": "string" },
+            "documentation-url": { "type": "string" },
+            "licence": { "type": "string" },
+            "attribution": { "type": "string" },
+            "entry-date": { "type": "string" },
+            "start-date": { "type": "string" },
+            "end-date": { "type": "string" }
+          }
+        },
+        "pipelines_append_required": {
+          "description": "Present when the source exists but serves multiple datasets — the existing pipelines value in source.csv needs to be updated to include the new dataset",
+          "type": "object",
+          "required": ["current", "updated"],
+          "properties": {
+            "current": {
+              "description": "The current value of the pipelines field in source.csv",
+              "type": "string",
+              "examples": ["article-4-direction-area"]
+            },
+            "updated": {
+              "description": "The value pipelines should be updated to (semicolon-delimited)",
+              "type": "string",
+              "examples": ["article-4-direction-area;article-4-direction"]
+            }
+          }
+        },
+        "existing_endpoint_for_organisation_dataset": {
+          "description": "Endpoint hashes already registered for this organisation and dataset combination",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "pipelineSummary": {
+      "type": "object",
+      "properties": {
+        "new-in-resource": { "type": "integer" },
+        "existing-in-resource": { "type": "integer" },
+        "new-entities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/entityEntry" }
+        },
+        "existing-entities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "entity": { "type": "string" },
+              "reference": { "type": "string" }
+            }
+          }
+        },
+        "entity-organisation": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dataset": { "type": "string" },
+              "organisation": { "type": "string" },
+              "entity-minimum": { "type": "integer" },
+              "entity-maximum": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "entityEntry": {
+      "type": "object",
+      "properties": {
+        "entity": { "type": "string" },
+        "prefix": { "type": "string" },
+        "reference": { "type": "string" },
+        "organisation": { "type": "string" },
+        "resource": { "type": "string" },
+        "entry-number": { "type": "string" },
+        "entry-date": { "type": "string" },
+        "start-date": { "type": "string" },
+        "end-date": { "type": "string" },
+        "endpoint": { "type": "string" }
+      }
+    }
+  }
+}

--- a/request-processor/src/application/core/utils.py
+++ b/request-processor/src/application/core/utils.py
@@ -468,7 +468,9 @@ def validate_source(
         # A combined endpoint can serve multiple datasets; if this dataset isn't already
         # listed in pipelines, the existing row needs to be updated with a semicolon-appended value.
         existing_pipelines = existing_entry.get("pipelines", "")
-        existing_pipeline_list = [p.strip() for p in existing_pipelines.split(";") if p.strip()]
+        existing_pipeline_list = [
+            p.strip() for p in existing_pipelines.split(";") if p.strip()
+        ]
         if dataset.strip() not in existing_pipeline_list:
             updated_pipelines = ";".join(existing_pipeline_list + [dataset.strip()])
             source_summary["pipelines_append_required"] = {

--- a/request-processor/src/application/core/utils.py
+++ b/request-processor/src/application/core/utils.py
@@ -465,6 +465,16 @@ def validate_source(
     existing_entry = _read_existing_source_entry(source_csv_path, source_key_returned)
     if existing_entry:
         source_summary["existing_source_entry"] = existing_entry
+        # A combined endpoint can serve multiple datasets; if this dataset isn't already
+        # listed in pipelines, the existing row needs to be updated with a semicolon-appended value.
+        existing_pipelines = existing_entry.get("pipelines", "")
+        existing_pipeline_list = [p.strip() for p in existing_pipelines.split(";") if p.strip()]
+        if dataset.strip() not in existing_pipeline_list:
+            updated_pipelines = ";".join(existing_pipeline_list + [dataset.strip()])
+            source_summary["pipelines_append_required"] = {
+                "current": existing_pipelines,
+                "updated": updated_pipelines,
+            }
     source_summary[
         "existing_endpoint_for_organisation_dataset"
     ] = existing_endpoint_for_org_dataset

--- a/request-processor/tests/data/specification/dataset-field.csv
+++ b/request-processor/tests/data/specification/dataset-field.csv
@@ -1,4 +1,4 @@
 dataset,field,field-dataset,guidance,hint
-tree,entry-date,,,
-tree,geometry,,,
-tree,reference,,,
+brownfield-land,entry-date,,,
+brownfield-land,geometry,,,
+brownfield-land,reference,,,

--- a/request-processor/tests/unit/src/application/core/test_utils.py
+++ b/request-processor/tests/unit/src/application/core/test_utils.py
@@ -509,6 +509,81 @@ def test_validate_source_finds_existing_source(monkeypatch, tmp_path):
     assert "existing_source_entry" in result
     assert result["existing_source_entry"]["source"] == "existing_source_hash"
     assert result["existing_source_entry"]["collection"] == collection
+    assert "pipelines_append_required" not in result
+
+
+def test_validate_source_pipelines_append_required(monkeypatch, tmp_path):
+    """Test validate_source flags pipelines_append_required when the dataset is not in the existing pipelines"""
+    pipeline_dir = tmp_path / "pipeline"
+    pipeline_dir.mkdir()
+    source_csv_path = pipeline_dir / "source.csv"
+
+    documentation_url = "http://example.com/doc"
+    collection = "article-4-direction"
+    organisation = "local-authority:SKP"
+    existing_dataset = "article-4-direction-area"
+    new_dataset = "article-4-direction"
+
+    endpoint_summary = {
+        "endpoint_url_in_endpoint_csv": True,
+        "existing_endpoint_entry": {"endpoint": "endpoint_hash_123"},
+    }
+
+    with open(source_csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "source",
+                "attribution",
+                "collection",
+                "documentation-url",
+                "endpoint",
+                "licence",
+                "organisation",
+                "pipelines",
+                "entry-date",
+                "start-date",
+                "end-date",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "source": "existing_source_hash",
+                "attribution": "",
+                "collection": collection,
+                "documentation-url": documentation_url,
+                "endpoint": "endpoint_hash_123",
+                "licence": "",
+                "organisation": organisation,
+                "pipelines": existing_dataset,
+                "entry-date": "2024-01-01T00:00:00",
+                "start-date": "2024-01-01",
+                "end-date": "",
+            }
+        )
+
+    def fake_append_source(*args, **kwargs):
+        return "existing_source_hash", None
+
+    monkeypatch.setattr("src.application.core.utils.append_source", fake_append_source)
+
+    result = validate_source(
+        documentation_url,
+        str(pipeline_dir),
+        collection,
+        organisation,
+        new_dataset,
+        endpoint_summary,
+        start_date=None,
+        licence=None,
+    )
+
+    assert result["documentation_url_in_source_csv"] is True
+    assert "existing_source_entry" in result
+    assert "pipelines_append_required" in result
+    assert result["pipelines_append_required"]["current"] == existing_dataset
+    assert result["pipelines_append_required"]["updated"] == f"{existing_dataset};{new_dataset}"
 
 
 def test_validate_source_no_endpoint_key(tmp_path):

--- a/request-processor/tests/unit/src/application/core/test_utils.py
+++ b/request-processor/tests/unit/src/application/core/test_utils.py
@@ -583,7 +583,10 @@ def test_validate_source_pipelines_append_required(monkeypatch, tmp_path):
     assert "existing_source_entry" in result
     assert "pipelines_append_required" in result
     assert result["pipelines_append_required"]["current"] == existing_dataset
-    assert result["pipelines_append_required"]["updated"] == f"{existing_dataset};{new_dataset}"
+    assert (
+        result["pipelines_append_required"]["updated"]
+        == f"{existing_dataset};{new_dataset}"
+    )
 
 
 def test_validate_source_no_endpoint_key(tmp_path):


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Detect when a combined multi-dataset endpoint requires a source pipelines update

When a source entry already exists in source.csv but the submitted dataset isn't listed in its pipelines field (i.e. the endpoint serves multiple datasets), validate_source now includes pipelines_append_required in the response. This contains the current and updated semicolon-delimited pipelines value so the caller knows a manual update to source.csv is needed rather than a new row.

Also adds docs/add-data-response.schema.json documenting all possible shapes of the add_data response, including all three source-summary variants.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=182646473&issue=digital-land%7Cconfig-manager%7C153
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Test adding a endpoint that already exists in the system, say https://raw.githubusercontent.com/digital-land/local-plan-extractor/refs/heads/main/dataset/local-plan.csv, this is an endpoint for local plans, but when adding say it is there for plan-timetable. Go through the usual process but now should see in the PR created you should see the pipelines column in the existing source csv entry for that endpoint haas been updated to show the dual datasets this endpoint works for.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Formalised JSON schema definition for data operation API responses, ensuring consistent structure and improved validation
  * Enhanced system capability to automatically detect and track when existing data source pipelines require updates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digital-land/async-request-backend/pull/110)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->