### PR TITLE
returns error on api failure and added tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,13 @@ volume
 __pycache__
 .venv
 .python-version
-
+.history/
 request-processor/src/digital-land
 request-processor/tests/converted
 request-processor/specification/*
 request-processor/var/*
+request-api/.venv
+request-api/venv
+request-processor/.venv
+request-processor/venv
 .DS_Store

--- a/request-api/src/main.py
+++ b/request-api/src/main.py
@@ -134,9 +134,9 @@ def healthcheck(
             ),
             DependencyHealth(
                 name="sqs",
-                status=HealthStatus.HEALTHY
-                if queue_reachable
-                else HealthStatus.UNHEALTHY,
+                status=(
+                    HealthStatus.HEALTHY if queue_reachable else HealthStatus.UNHEALTHY
+                ),
             ),
         ],
     )

--- a/request-api/tests/integration/test_main.py
+++ b/request-api/tests/integration/test_main.py
@@ -116,9 +116,9 @@ def test_get_db_fails_after_retries(mock_restored, mock_slack, mock_session_make
 @patch("main.WebClient")
 @patch(
     "main.os.environ.get",
-    side_effect=lambda k, d=None: "fake_token"
-    if k == "SLACK_BOT_TOKEN"
-    else "fake_channel",
+    side_effect=lambda k, d=None: (
+        "fake_token" if k == "SLACK_BOT_TOKEN" else "fake_channel"
+    ),
 )
 def test_send_slack_alert(mock_env, mock_webclient):
     mock_client_instance = mock_webclient.return_value

--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -51,7 +51,7 @@ def fetch_response_data(
                 endpoints=[],
             )
     except Exception as err:
-        logger.exception("An exception occurred during Pipeline Transform: %s", err)
+        logger.exception("An exception occurred when assigning entries: %s", err)
         raise
 
     # Create directories if they don't exist
@@ -109,7 +109,7 @@ def fetch_response_data(
                 ),
             )
         except Exception as err:
-            logger.error("An exception occured during Pipeline Transform: %s", str(err))
+            logger.exception("An exception occurred during Pipeline Transform: %s", err)
             raise
 
 

--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -51,7 +51,7 @@ def fetch_response_data(
                 endpoints=[],
             )
     except Exception as err:
-        logger.error("An exception occured during assign_entries process: %s", str(err))
+        logger.exception("An exception occurred during Pipeline Transform: %s", err)
         raise
 
     # Create directories if they don't exist
@@ -109,7 +109,7 @@ def fetch_response_data(
                 ),
             )
         except Exception as err:
-            logger.error("An exception occured during Pipeline Transform: ", str(err))
+            logger.error("An exception occured during Pipeline Transform: %s", str(err))
             raise
 
 

--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -202,6 +202,13 @@ def fetch_add_data_response(
     endpoint,
     converted_path=None,
 ):
+    """
+    Run the add-data pipeline transform and build the pipeline summary response.
+
+    This is reached via POST /requests with type "add_data" through the
+    AddDataTask and add_data_workflow. Processing exceptions are re-raised so
+    add_data_workflow can return them in the standard async error response.
+    """
     try:
         specification = Specification(specification_dir)
         pipeline = Pipeline(pipeline_dir, dataset, specification=specification)
@@ -294,8 +301,8 @@ def fetch_add_data_response(
                     logger.info(f"No unidentified lookups found in {resource_file}")
 
             except Exception as err:
-                logger.error(f"Error processing {resource_file}: {err}")
-                logger.exception("Full traceback: ")
+                logger.exception(f"Error processing {resource_file}: {err}")
+                raise
 
         new_entities_breakdown = _get_entities_breakdown(new_entities)
         existing_entities_breakdown = _get_existing_entities_breakdown(

--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -52,6 +52,7 @@ def fetch_response_data(
             )
     except Exception as err:
         logger.error("An exception occured during assign_entries process: %s", str(err))
+        raise
 
     # Create directories if they don't exist
     for directory in [
@@ -109,6 +110,7 @@ def fetch_response_data(
             )
         except Exception as err:
             logger.error("An exception occured during Pipeline Transform: ", str(err))
+            raise
 
 
 def resource_from_path(path):

--- a/request-processor/src/application/core/workflow.py
+++ b/request-processor/src/application/core/workflow.py
@@ -123,6 +123,11 @@ def run_workflow(
         # logger.info("Error Summary: %s", summary_data)
     except Exception as e:
         logger.exception(f"An error occurred: {e}")
+        response_data = {
+            "message": f"An error occurred during workflow processing: {e}",
+            "status": 500,
+            "exception": type(e).__name__,
+        }
 
     finally:
         clean_up(

--- a/request-processor/src/application/core/workflow.py
+++ b/request-processor/src/application/core/workflow.py
@@ -124,7 +124,7 @@ def run_workflow(
     except Exception as e:
         logger.exception(f"An error occurred: {e}")
         response_data = {
-            "message": f"An error occurred during workflow processing: {e}",
+            "message": f"An error occurred during workflow processing.",
             "status": 500,
             "exception": type(e).__name__,
         }

--- a/request-processor/tests/unit/src/application/core/test_pipeline.py
+++ b/request-processor/tests/unit/src/application/core/test_pipeline.py
@@ -400,6 +400,47 @@ def test_fetch_add_data_response_handles_processing_error(monkeypatch, tmp_path)
     assert result["new-in-resource"] == 0
 
 
+def test_fetch_add_data_response_reraises_processing_error(monkeypatch, tmp_path):
+    dataset = "test-dataset"
+    organisation = "test-org"
+    pipeline_dir = tmp_path / "pipeline"
+    input_path = tmp_path / "resource"
+    specification_dir = tmp_path / "specification"
+    cache_dir = tmp_path / "cache"
+    endpoint = "abc123hash"
+
+    input_path.mkdir(parents=True)
+    pipeline_dir.mkdir(parents=True)
+
+    test_file = input_path / "test.csv"
+    test_file.write_text("invalid csv content without proper headers")
+
+    mock_spec = MagicMock()
+    mock_spec.dataset_prefix.return_value = "test-prefix"
+    mock_pipeline = MagicMock()
+    mock_pipeline.transform.side_effect = Exception("Processing error")
+
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Specification", lambda x: mock_spec
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Pipeline", MagicMock(return_value=mock_pipeline)
+    )
+    monkeypatch.setattr("src.application.core.pipeline.Organisation", MagicMock())
+
+    with pytest.raises(Exception, match="Processing error"):
+        fetch_add_data_response(
+            dataset=dataset,
+            organisation_provider=organisation,
+            pipeline_dir=str(pipeline_dir),
+            input_dir=str(input_path),
+            output_path=str(input_path / "output.csv"),
+            specification_dir=str(specification_dir),
+            cache_dir=str(cache_dir),
+            endpoint=endpoint,
+        )
+
+
 def test_get_entities_breakdown_success():
     """Test converting entities to breakdown format"""
     new_entities = [

--- a/request-processor/tests/unit/src/application/core/test_pipeline.py
+++ b/request-processor/tests/unit/src/application/core/test_pipeline.py
@@ -90,6 +90,140 @@ def test_fetch_response_data_calls_assign_entries_with_expected_params(
     )
 
 
+def test_fetch_response_data_reraises_assign_entries_exception(monkeypatch, tmp_path):
+    dataset = "test-dataset"
+    organisation = "test-org"
+    request_id = "request-123"
+    collection_dir = tmp_path / "collection"
+    converted_dir = tmp_path / "converted"
+    issue_dir = tmp_path / "issue"
+    column_field_dir = tmp_path / "column-field"
+    transformed_dir = tmp_path / "transformed"
+    dataset_resource_dir = tmp_path / "dataset-resource"
+    pipeline_dir = tmp_path / "pipeline"
+    specification_dir = tmp_path / "specification"
+    cache_dir = tmp_path / "cache"
+
+    input_dir = collection_dir / "resource" / request_id
+    input_dir.mkdir(parents=True)
+    resource_file = input_dir / "resource-hash.csv"
+    resource_file.write_text("reference\nREF001\n")
+
+    converted_dir.mkdir()
+    pipeline_dir.mkdir()
+    specification_dir.mkdir()
+    cache_dir.mkdir()
+
+    mock_specification = MagicMock()
+    mock_pipeline = MagicMock()
+    mock_api = MagicMock()
+    assign_entries = MagicMock(side_effect=RuntimeError("assign failed"))
+
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Specification",
+        MagicMock(return_value=mock_specification),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Pipeline",
+        MagicMock(return_value=mock_pipeline),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.API",
+        MagicMock(return_value=mock_api),
+    )
+    monkeypatch.setattr("src.application.core.pipeline.assign_entries", assign_entries)
+
+    with pytest.raises(RuntimeError, match="assign failed"):
+        fetch_response_data(
+            dataset=dataset,
+            organisation=organisation,
+            request_id=request_id,
+            collection_dir=str(collection_dir),
+            converted_dir=str(converted_dir),
+            issue_dir=str(issue_dir),
+            column_field_dir=str(column_field_dir),
+            transformed_dir=str(transformed_dir),
+            dataset_resource_dir=str(dataset_resource_dir),
+            pipeline_dir=str(pipeline_dir),
+            specification_dir=str(specification_dir),
+            cache_dir=str(cache_dir),
+            additional_col_mappings=None,
+            additional_concats=None,
+        )
+
+
+def test_fetch_response_data_reraises_pipeline_transform_exception(
+    monkeypatch, tmp_path
+):
+    dataset = "test-dataset"
+    organisation = "test-org"
+    request_id = "request-123"
+    collection_dir = tmp_path / "collection"
+    converted_dir = tmp_path / "converted"
+    issue_dir = tmp_path / "issue"
+    column_field_dir = tmp_path / "column-field"
+    transformed_dir = tmp_path / "transformed"
+    dataset_resource_dir = tmp_path / "dataset-resource"
+    pipeline_dir = tmp_path / "pipeline"
+    specification_dir = tmp_path / "specification"
+    cache_dir = tmp_path / "cache"
+
+    input_dir = collection_dir / "resource" / request_id
+    input_dir.mkdir(parents=True)
+    resource_file = input_dir / "resource-hash.csv"
+    resource_file.write_text("reference\nREF001\n")
+
+    converted_dir.mkdir()
+    pipeline_dir.mkdir()
+    specification_dir.mkdir()
+    cache_dir.mkdir()
+
+    mock_specification = MagicMock()
+    mock_pipeline = MagicMock()
+    mock_pipeline.path = str(pipeline_dir)
+    mock_pipeline.transform.side_effect = RuntimeError("transform failed")
+    mock_api = MagicMock()
+    mock_api.get_valid_category_values.return_value = {"category": ["value"]}
+    mock_organisation = MagicMock()
+    assign_entries = MagicMock()
+
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Specification",
+        MagicMock(return_value=mock_specification),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Pipeline",
+        MagicMock(return_value=mock_pipeline),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.API",
+        MagicMock(return_value=mock_api),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Organisation",
+        MagicMock(return_value=mock_organisation),
+    )
+    monkeypatch.setattr("src.application.core.pipeline.assign_entries", assign_entries)
+
+    with pytest.raises(RuntimeError, match="transform failed"):
+        fetch_response_data(
+            dataset=dataset,
+            organisation=organisation,
+            request_id=request_id,
+            collection_dir=str(collection_dir),
+            converted_dir=str(converted_dir),
+            issue_dir=str(issue_dir),
+            column_field_dir=str(column_field_dir),
+            transformed_dir=str(transformed_dir),
+            dataset_resource_dir=str(dataset_resource_dir),
+            pipeline_dir=str(pipeline_dir),
+            specification_dir=str(specification_dir),
+            cache_dir=str(cache_dir),
+            additional_col_mappings=None,
+            additional_concats=None,
+        )
+
+
 def test_fetch_add_data_response_success(monkeypatch, tmp_path):
     """Test successful execution of fetch_add_data_response"""
     dataset = "test-dataset"

--- a/request-processor/tests/unit/src/application/core/test_pipeline.py
+++ b/request-processor/tests/unit/src/application/core/test_pipeline.py
@@ -1,10 +1,93 @@
 import pytest
 from unittest.mock import MagicMock
 from src.application.core.pipeline import (
+    fetch_response_data,
     fetch_add_data_response,
     _get_entities_breakdown,
     _get_existing_entities_breakdown,
 )
+
+
+def test_fetch_response_data_calls_assign_entries_with_expected_params(
+    monkeypatch, tmp_path
+):
+    dataset = "test-dataset"
+    organisation = "test-org"
+    request_id = "request-123"
+    collection_dir = tmp_path / "collection"
+    converted_dir = tmp_path / "converted"
+    issue_dir = tmp_path / "issue"
+    column_field_dir = tmp_path / "column-field"
+    transformed_dir = tmp_path / "transformed"
+    dataset_resource_dir = tmp_path / "dataset-resource"
+    pipeline_dir = tmp_path / "pipeline"
+    specification_dir = tmp_path / "specification"
+    cache_dir = tmp_path / "cache"
+
+    input_dir = collection_dir / "resource" / request_id
+    input_dir.mkdir(parents=True)
+    resource_file = input_dir / "resource-hash.csv"
+    resource_file.write_text("reference\nREF001\n")
+
+    converted_dir.mkdir()
+    pipeline_dir.mkdir()
+    specification_dir.mkdir()
+    cache_dir.mkdir()
+
+    mock_specification = MagicMock()
+    mock_issue_log = MagicMock()
+    mock_pipeline = MagicMock()
+    mock_pipeline.path = str(pipeline_dir)
+    mock_pipeline.transform.return_value = mock_issue_log
+    mock_api = MagicMock()
+    mock_api.get_valid_category_values.return_value = {"category": ["value"]}
+    mock_organisation = MagicMock()
+    assign_entries = MagicMock()
+
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Specification",
+        MagicMock(return_value=mock_specification),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Pipeline",
+        MagicMock(return_value=mock_pipeline),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.API",
+        MagicMock(return_value=mock_api),
+    )
+    monkeypatch.setattr(
+        "src.application.core.pipeline.Organisation",
+        MagicMock(return_value=mock_organisation),
+    )
+    monkeypatch.setattr("src.application.core.pipeline.assign_entries", assign_entries)
+
+    fetch_response_data(
+        dataset=dataset,
+        organisation=organisation,
+        request_id=request_id,
+        collection_dir=str(collection_dir),
+        converted_dir=str(converted_dir),
+        issue_dir=str(issue_dir),
+        column_field_dir=str(column_field_dir),
+        transformed_dir=str(transformed_dir),
+        dataset_resource_dir=str(dataset_resource_dir),
+        pipeline_dir=str(pipeline_dir),
+        specification_dir=str(specification_dir),
+        cache_dir=str(cache_dir),
+        additional_col_mappings=None,
+        additional_concats=None,
+    )
+
+    assign_entries.assert_called_once_with(
+        resource_path=str(resource_file),
+        dataset=dataset,
+        organisation=organisation,
+        pipeline_dir=str(pipeline_dir),
+        specification=mock_specification,
+        cache_dir=str(cache_dir),
+        endpoints=[],
+    )
 
 
 def test_fetch_add_data_response_success(monkeypatch, tmp_path):

--- a/request-processor/tests/unit/src/application/core/test_workflow.py
+++ b/request-processor/tests/unit/src/application/core/test_workflow.py
@@ -1,5 +1,6 @@
 import pytest
 from src.application.core.workflow import (
+    run_workflow,
     updateColumnFieldLog,
     error_summary,
     csv_to_json,
@@ -308,6 +309,38 @@ def test_fetch_pipelines(
 
                 for row in expected_rows:
                     assert row in csv_rows
+
+
+def test_run_workflow_returns_error_response_when_pipeline_fails(
+    monkeypatch, mock_directories
+):
+    def raise_pipeline_error(*args, **kwargs):
+        raise RuntimeError("assign entries failed")
+
+    monkeypatch.setattr(
+        "src.application.core.workflow.fetch_pipeline_csvs", lambda *args: {}
+    )
+    monkeypatch.setattr(
+        "src.application.core.workflow.fetch_response_data", raise_pipeline_error
+    )
+    monkeypatch.setattr("src.application.core.workflow.clean_up", lambda *args: None)
+
+    result = run_workflow(
+        "data.csv",
+        "request-123",
+        "test-collection",
+        "test-dataset",
+        "test-org",
+        "",
+        {},
+        mock_directories,
+    )
+
+    assert result == {
+        "message": "An error occurred during workflow processing: assign entries failed",
+        "status": 500,
+        "exception": "RuntimeError",
+    }
 
 
 def test_add_data_workflow(monkeypatch):

--- a/request-processor/tests/unit/src/application/core/test_workflow.py
+++ b/request-processor/tests/unit/src/application/core/test_workflow.py
@@ -337,7 +337,7 @@ def test_run_workflow_returns_error_response_when_pipeline_fails(
     )
 
     assert result == {
-        "message": "An error occurred during workflow processing: assign entries failed",
+        "message": "An error occurred during workflow processing.",
         "status": 500,
         "exception": "RuntimeError",
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Stops request processor pipeline errors from being silently swallowed. Errors raised during `assign_entries` or pipeline transform now bubble up into `run_workflow`, where they are returned in the existing error response shape with `message`, `status`, and `exception`.

Also adds unit coverage for `fetch_response_data`, including an assertion that `assign_entries` is called with the expected params.

## Related Tickets & Documents

- Ticket Link: N/A
- Related Issue #: N/A
- Closes #: N/A

## QA Instructions, Screenshots, Recordings


Also verified `request-api` tests pass:

```bash
cd request-api
make test
```

No UI changes, so no screenshots or recordings are included.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to re-surface exceptions and return structured error responses containing message, status (500) and exception type.

* **Tests**
  * Added unit tests to verify error propagation and workflow error responses.
  * Updated an integration test to ensure alert-related environment values are resolved correctly.

* **Chores**
  * Updated ignore patterns to exclude local virtual environments and temporary directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digital-land/async-request-backend/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->