### PR TITLE
Add endpoint and logic to retrieve response geometries

### DIFF
--- a/request-api/src/crud.py
+++ b/request-api/src/crud.py
@@ -50,6 +50,52 @@ def get_response_details(
     )
 
 
+def get_response_geometries(db: Session, request_id: int):
+    transformed_rows = (
+        db.query(models.ResponseDetails.detail["transformed_row"])
+        .join(models.ResponseDetails.response)
+        .filter(models.Response.request_id == request_id)
+        .order_by(models.ResponseDetails.id)
+        .all()
+    )
+
+    geometry_key = None
+    for (transformed_row,) in transformed_rows:
+        if not transformed_row:
+            continue
+        geometry_field = next(
+            (
+                field
+                for field in transformed_row
+                if field.get("field") in ("geometry", "point")
+            ),
+            None,
+        )
+        if geometry_field is not None:
+            geometry_key = geometry_field.get("field")
+            break
+
+    geometries = []
+    if geometry_key is not None:
+        for (transformed_row,) in transformed_rows:
+            if not transformed_row:
+                continue
+            geometry = next(
+                (
+                    field.get("value")
+                    for field in transformed_row
+                    if field.get("field") == geometry_key
+                    and isinstance(field.get("value"), str)
+                    and field.get("value").strip()
+                ),
+                None,
+            )
+            if geometry:
+                geometries.append(geometry)
+
+    return geometries
+
+
 def create_request(db: Session, request: schemas.RequestCreate):
     db_request = models.Request(
         status="NEW", type=request.params.type, params=request.params.model_dump()

--- a/request-api/src/main.py
+++ b/request-api/src/main.py
@@ -208,6 +208,11 @@ def read_response_details(
     return list(map(lambda detail: detail.detail, paginated_result.data))
 
 
+@app.get("/requests/{request_id}/geometries", response_model=List[str])
+def read_response_geometries(request_id: str, db: Session = Depends(_get_db)):
+    return crud.get_response_geometries(db, request_id)
+
+
 def _map_to_schema(request_model: models.Request) -> schemas.Request:
     response = None
     if request_model.response:

--- a/request-api/tests/integration/test_main.py
+++ b/request-api/tests/integration/test_main.py
@@ -260,6 +260,16 @@ def test_read_response_details_limit1_jsonpath(
     )
 
 
+def test_read_response_geometries(db, geometry_test_request):
+    response = client.get(f"/requests/{geometry_test_request.id}/geometries")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        "MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)))",
+        "MULTIPOLYGON (((2 2, 3 3, 3 2, 2 2)))",
+    ]
+
+
 def test_read_unknown_request(db):
     response = client.get("/requests/0")
     assert response.status_code == 404
@@ -346,6 +356,72 @@ def test_request():
                 ),
                 models.ResponseDetails(
                     detail={"line": 3, "issue_logs": [{"severity": "warning"}]}
+                ),
+            ],
+        ),
+    )
+    db_session = database.session_maker()
+    with db_session() as session:
+        session.add(request_model)
+        session.commit()
+        session.refresh(request_model)
+        return request_model
+
+
+@pytest.fixture(scope="module")
+def geometry_test_request():
+    request_model = models.Request(
+        type=schemas.RequestTypeEnum.check_file,
+        created=datetime.datetime.now(),
+        modified=datetime.datetime.now(),
+        status="COMPLETE",
+        params=schemas.CheckFileParams(
+            collection="article-4-direction",
+            dataset="article-4-direction-area",
+            original_filename="article-direction-area.csv",
+            uploaded_filename="492f15d8-45e4-427e-bde0-f60d69889f40",
+        ).model_dump(),
+        response=models.Response(
+            data='{ "some_key": "some_value" }',
+            details=[
+                models.ResponseDetails(
+                    detail={
+                        "entry_number": 1,
+                        "transformed_row": [
+                            {"field": "reference", "value": "abc"},
+                            {
+                                "field": "geometry",
+                                "value": "MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)))",
+                            },
+                        ],
+                    }
+                ),
+                models.ResponseDetails(
+                    detail={
+                        "entry_number": 2,
+                        "transformed_row": [
+                            {"field": "reference", "value": "def"},
+                            {"field": "point", "value": "POINT (0 0)"},
+                        ],
+                    }
+                ),
+                models.ResponseDetails(
+                    detail={
+                        "entry_number": 3,
+                        "transformed_row": [
+                            {"field": "reference", "value": "ghi"},
+                            {
+                                "field": "geometry",
+                                "value": "MULTIPOLYGON (((2 2, 3 3, 3 2, 2 2)))",
+                            },
+                        ],
+                    }
+                ),
+                models.ResponseDetails(
+                    detail={
+                        "entry_number": 4,
+                        "transformed_row": [{"field": "reference", "value": "jkl"}],
+                    }
                 ),
             ],
         ),

--- a/request-processor/tests/unit/src/application/core/test_workflow.py
+++ b/request-processor/tests/unit/src/application/core/test_workflow.py
@@ -622,8 +622,7 @@ def test_download_file_does_not_add_token_for_non_github_download(
 
 def test_github_installation_token_uses_timeout(monkeypatch):
     requests = []
-    _GITHUB_CONFIG_TOKEN_CACHE["token"] = None
-    _GITHUB_CONFIG_TOKEN_CACHE["expires_at"] = 0
+    original_cache = _GITHUB_CONFIG_TOKEN_CACHE.copy()
 
     class FakeResponse:
         def __enter__(self):
@@ -647,18 +646,25 @@ def test_github_installation_token_uses_timeout(monkeypatch):
     )
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
-    token = _github_installation_token(
-        {
-            "app_id": "123",
-            "installation_id": "456",
-            "private_key": "private-key",
-        }
-    )
+    try:
+        _GITHUB_CONFIG_TOKEN_CACHE["token"] = None
+        _GITHUB_CONFIG_TOKEN_CACHE["expires_at"] = 0
 
-    request, timeout = requests[0]
-    assert token == "installation-token"
-    assert request.full_url.endswith("/app/installations/456/access_tokens")
-    assert timeout == REQUEST_TIMEOUT_SECONDS
+        token = _github_installation_token(
+            {
+                "app_id": "123",
+                "installation_id": "456",
+                "private_key": "private-key",
+            }
+        )
+
+        request, timeout = requests[0]
+        assert token == "installation-token"
+        assert request.full_url.endswith("/app/installations/456/access_tokens")
+        assert timeout == REQUEST_TIMEOUT_SECONDS
+    finally:
+        _GITHUB_CONFIG_TOKEN_CACHE.clear()
+        _GITHUB_CONFIG_TOKEN_CACHE.update(original_cache)
 
 
 COLUMN_CSV_FIELDNAMES = ["dataset", "resource", "column", "field"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adds a dedicated `/requests/{request_id}/geometries` endpoint to the request API so the frontend can fetch map geometry data separately from paginated `/response-details`.

The endpoint reads geometry values from `transformed_row`, matching the previous frontend behavior: it determines whether to use `geometry` or `point` from the first row that has either field, then returns non-empty values for that same field across all rows.

## Related Tickets & Documents

- Ticket Link: https://github.com/digital-land/config/issues/2658
- Related Issue #2658
- Closes #2658

## QA Instructions, Screenshots, Recordings

Run the request API tests, especially:

```bash
cd request-api
python -m pytest tests/unit/test_crud.py tests/integration/test_main.py
```

Manual QA:
- Load a check results page for a large geographic dataset.
- Confirm `/response-details` is only fetched for the current page.
- Confirm `/requests/{request_id}/geometries` is called separately for map data.
- Confirm the map still renders geometries.
- Confirm table pagination continues to work.

No screenshots included; API/backend change only.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

Depends on frontend work updating the results page to use the dedicated geometries endpoint instead of relying on fully fetched `/response-details` rows for map data.