### PR TITLE
Fix column mapping for tree polygons and enhance tests for geometry h…

### DIFF
--- a/request-processor/src/application/core/workflow.py
+++ b/request-processor/src/application/core/workflow.py
@@ -314,8 +314,9 @@ def fetch_pipeline_csvs(
 ):
     os.makedirs(pipeline_dir, exist_ok=True)
     pipeline_csvs = ["column.csv", "transform.csv"]
-    downloaded = False
+    not_mapped_columns = []
     for pipeline_csv in pipeline_csvs:
+        downloaded = False
         try:
             csv_path = os.path.join(pipeline_dir, pipeline_csv)
             print(
@@ -345,6 +346,10 @@ def fetch_pipeline_csvs(
         if downloaded:
             try:
                 if pipeline_csv == "column.csv":
+                    if geom_type:
+                        add_geom_mapping(
+                            dataset, pipeline_dir, geom_type, resource, pipeline_csv
+                        )
                     if column_mapping:
                         not_mapped_columns = add_extra_column_mappings(
                             csv_path,
@@ -353,14 +358,9 @@ def fetch_pipeline_csvs(
                             resource,
                             specification,
                         )
-                        return not_mapped_columns
-                    if geom_type:
-                        add_geom_mapping(
-                            dataset, pipeline_dir, geom_type, resource, pipeline_csv
-                        )
             except Exception as e:
                 logger.error(f"Error saving new csv mapping: {e}")
-    return {}
+    return not_mapped_columns
 
 
 def add_geom_mapping(dataset, pipeline_dir, geom_type, resource, pipeline_csv):
@@ -740,6 +740,10 @@ def fetch_add_data_pipeline_csvs(
         else:
             column_csv_path = os.path.join(pipeline_dir, "column.csv")
             try:
+                if geom_type and resource and dataset:
+                    add_geom_mapping(
+                        dataset, pipeline_dir, geom_type, resource, "column.csv"
+                    )
                 if column_mapping and resource and dataset and specification:
                     add_extra_column_mappings(
                         column_csv_path,
@@ -748,10 +752,6 @@ def fetch_add_data_pipeline_csvs(
                         resource,
                         specification,
                         endpoint_hash=endpoint_hash,
-                    )
-                elif geom_type and resource and dataset:
-                    add_geom_mapping(
-                        dataset, pipeline_dir, geom_type, resource, "column.csv"
                     )
             except Exception as e:
                 logger.error(f"Error saving column mappings to column.csv: {e}")
@@ -769,6 +769,10 @@ def fetch_add_data_pipeline_csvs(
 
         if csv_name == "column.csv":
             try:
+                if geom_type and resource and dataset:
+                    add_geom_mapping(
+                        dataset, pipeline_dir, geom_type, resource, csv_name
+                    )
                 if column_mapping and resource and dataset and specification:
                     add_extra_column_mappings(
                         csv_path,
@@ -777,10 +781,6 @@ def fetch_add_data_pipeline_csvs(
                         resource,
                         specification,
                         endpoint_hash=endpoint_hash,
-                    )
-                elif geom_type and resource and dataset:
-                    add_geom_mapping(
-                        dataset, pipeline_dir, geom_type, resource, csv_name
                     )
             except Exception as e:
                 logger.error(f"Error saving column mappings to column.csv: {e}")

--- a/request-processor/src/application/core/workflow.py
+++ b/request-processor/src/application/core/workflow.py
@@ -359,7 +359,7 @@ def fetch_pipeline_csvs(
                             dataset, pipeline_dir, geom_type, resource, pipeline_csv
                         )
             except Exception as e:
-                logger.error(f"Error saving new mapping: {e}")
+                logger.error(f"Error saving new csv mapping: {e}")
     return {}
 
 

--- a/request-processor/tests/conftest.py
+++ b/request-processor/tests/conftest.py
@@ -167,6 +167,13 @@ def mock_extract_dataset_field_rows(mock_directories):
                 "guidance": "",
                 "hint": "",
             },
+            {
+                "dataset": dataset_name,
+                "field": "start-date",
+                "field-dataset": "",
+                "guidance": "",
+                "hint": "",
+            },
         ]
         fieldnames = rows[0].keys()
         with open(mock_field_csv, "w") as f:

--- a/request-processor/tests/integration/src/application/core/test_workflow.py
+++ b/request-processor/tests/integration/src/application/core/test_workflow.py
@@ -292,7 +292,7 @@ def test_run_workflow_brownfield_land(
     dataset = "brownfield-land"
     organisation = "local-authority:CTY"
     geom_type = ""
-    column_mapping = {"ref": "reference"}
+    column_mapping = {"ref": "reference", "start_date": "start-date"}
     fileName = uploaded_csv_brownfield_land
     source_organisation_csv = f"{test_data_dir}/csvs/organisation.csv"
     destination_organisation_csv = os.path.join(

--- a/request-processor/tests/unit/src/application/core/test_workflow.py
+++ b/request-processor/tests/unit/src/application/core/test_workflow.py
@@ -588,6 +588,58 @@ def test_fetch_add_data_pipeline_csvs_handles_http_error(monkeypatch, tmp_path):
     assert os.path.exists(pipeline_dir_str)
 
 
+def test_fetch_add_data_pipeline_csvs_applies_geom_and_column_mapping(
+    monkeypatch, tmp_path
+):
+    collection = "tree-collection"
+    pipeline_dir = tmp_path / "pipeline"
+    monkeypatch.setattr(
+        "src.application.core.workflow.CONFIG_URL", "http://example.com/config/"
+    )
+
+    def fake_download_file(url, path):
+        if path.endswith("column.csv"):
+            _write_column_csv(
+                path,
+                [
+                    {
+                        "dataset": "tree",
+                        "resource": "resource-hash",
+                        "column": "id",
+                        "field": "reference",
+                    }
+                ],
+            )
+        else:
+            with open(path, "w") as f:
+                f.write("dummy data")
+
+    monkeypatch.setattr(
+        "src.application.core.workflow.download_file", fake_download_file
+    )
+    mock_spec = MagicMock(dataset_field={"tree": ["geometry", "reference"]})
+
+    fetch_add_data_pipeline_csvs(
+        collection,
+        str(pipeline_dir),
+        column_mapping={"na": "IGNORE"},
+        geom_type="polygon",
+        resource="resource-hash",
+        dataset="tree",
+        specification=mock_spec,
+    )
+
+    with open(pipeline_dir / "column.csv", newline="") as f:
+        rows = list(csv.DictReader(f))
+
+    assert {
+        "dataset": "tree",
+        "resource": "resource-hash",
+        "column": "WKT",
+        "field": "geometry",
+    } in rows
+
+
 def test_download_file_does_not_add_auth_without_github_env(monkeypatch, tmp_path):
     destination = tmp_path / "column.csv"
     requests = []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes column mapping handling for tree polygon check URL workflows. Previously, when `column_mapping` was supplied, the workflow returned before applying the `geom_type` mapping. This prevented the tree polygon `WKT -> geometry` mapping from being added.

This change makes geometry mapping and explicit column mappings additive: `geom_type` mapping is applied first, then any supplied `column_mapping` is appended afterwards. It also avoids returning early so the remaining pipeline CSVs continue to download.

## Related Tickets & Documents

- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Run:

```bash
cd request-processor
venv/bin/python -m pytest tests/unit/src/application/core/test_workflow.py -vv
venv/bin/python -m black --check --exclude "digital-land" ./src ./tests
venv/bin/python -m flake8 --exclude="./src/digital-land" ./src ./tests
```

Confirmed the workflow now keeps `WKT -> geometry` for tree polygon data while also applying explicit column mappings such as `na -> IGNORE`.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline CSV handling now preserves unmapped columns instead of dropping them.
  * Geometry and column mappings can now be applied together when fetching additional pipeline data, so both sets of changes appear in the resulting CSV.
  * Improved consistency in generated `column.csv` output for pipeline downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->