### PR TITLE
Implement non-spatial dataset handling and enhance old entity redirec…

### DIFF
--- a/request-processor/src/application/core/duplicates.py
+++ b/request-processor/src/application/core/duplicates.py
@@ -190,7 +190,9 @@ def _match_platform_dataset_entities(
         )
 
         comparisons = []
-        for field, comparison_column in zip(comparison_fields, comparison_column_names):
+        for field, comparison_column in zip(
+            comparison_fields, comparison_column_names, strict=True
+        ):
             platform_column = platform_columns_by_normalised_name.get(field)
             if field == "organisation":
                 platform_expression = platform_organisation_expression
@@ -229,7 +231,7 @@ def _match_platform_dataset_entities(
         result_columns = [description[0] for description in cursor.description]
         provision_by_id = {str(row.get("entity", "")): row for row in provision_rows}
         for values in cursor.fetchall():
-            result = dict(zip(result_columns, values))
+            result = dict(zip(result_columns, values, strict=True))
             new_entity_id = str(result.pop("__new_entity", "") or "")
             normalised_organisation = str(
                 result.pop("__normalised_organisation", "") or ""
@@ -470,10 +472,18 @@ def _build_non_spatial_candidate(
         "notes": REDIRECT_NOTE,
         "old_name": str(old_entity.get("name", "") or ""),
         "new_name": str(new_entity.get("name", "") or ""),
-        "old_entry_date": str(old_entity.get("entry-date", "") or ""),
-        "new_entry_date": str(new_entity.get("entry-date", "") or ""),
-        "old_end_date": str(old_entity.get("end-date", "") or ""),
-        "new_end_date": str(new_entity.get("end-date", "") or ""),
+        "old_entry_date": str(
+            old_entity.get("entry-date", "") or old_entity.get("entry_date", "") or ""
+        ),
+        "new_entry_date": str(
+            new_entity.get("entry-date", "") or new_entity.get("entry_date", "") or ""
+        ),
+        "old_end_date": str(
+            old_entity.get("end-date", "") or old_entity.get("end_date", "") or ""
+        ),
+        "new_end_date": str(
+            new_entity.get("end-date", "") or new_entity.get("end_date", "") or ""
+        ),
         "old_organisation": str(old_entity.get("organisation", "") or ""),
         "new_organisation": str(new_entity.get("organisation", "") or ""),
         "old_organisation_entity": str(
@@ -560,7 +570,7 @@ def _find_non_spatial_candidates(
         logger.exception(
             "Failed to compare platform dataset %s for duplicates: %s", dataset, err
         )
-        return []
+        raise
 
     return candidates
 

--- a/request-processor/src/application/core/duplicates.py
+++ b/request-processor/src/application/core/duplicates.py
@@ -17,13 +17,11 @@ DATASETTE_BASE_URL = os.getenv(
     "DATASETTE_BASE_URL", "https://datasette.planning.data.gov.uk"
 )
 REDIRECT_NOTE = "Redirect duplicate entity selected in Assign Entities"
-NON_SPATIAL_EXCLUDED_FIELDS = {
-    "reference",
-    "entry-date",
-    "notes",
-    "description",
-    "organisation-entity",
-    "organisation_entity",
+NON_SPATIAL_COMPARISON_FIELDS = {
+    "name",
+    "start-date",
+    "doc-url",
+    "document-url",
 }
 
 
@@ -89,8 +87,7 @@ def _non_spatial_comparison_fields(provision_rows: list[dict]) -> list[str]:
         str(field).strip().lower()
         for row in provision_rows
         for field in row
-        if field != "entity"
-        and str(field).strip().lower() not in NON_SPATIAL_EXCLUDED_FIELDS
+        if str(field).strip().lower() in NON_SPATIAL_COMPARISON_FIELDS
     }
     return sorted(field for field in fields if field)
 

--- a/request-processor/src/application/core/duplicates.py
+++ b/request-processor/src/application/core/duplicates.py
@@ -1,11 +1,14 @@
-import csv
 import os
 import sqlite3
 import tempfile
+from contextlib import contextmanager
+from urllib.parse import quote
 
+import duckdb
 import requests
 from rapidfuzz import fuzz
 
+from application.configurations.config import DATASTORE_URL
 from application.logging.logger import get_logger
 
 logger = get_logger(__name__)
@@ -14,6 +17,14 @@ DATASETTE_BASE_URL = os.getenv(
     "DATASETTE_BASE_URL", "https://datasette.planning.data.gov.uk"
 )
 REDIRECT_NOTE = "Redirect duplicate entity selected in Assign Entities"
+NON_SPATIAL_EXCLUDED_FIELDS = {
+    "reference",
+    "entry-date",
+    "notes",
+    "description",
+    "organisation-entity",
+    "organisation_entity",
+}
 
 
 def _normalise_entity_id(raw) -> str:
@@ -36,29 +47,200 @@ def _read_provision_entities(transformed_csv_path: str) -> list:
     if not os.path.exists(transformed_csv_path):
         return []
 
-    entity_fields = {
-        "reference",
-        "name",
-        "geometry",
-        "point",
-        "organisation",
-        "organisation_entity",
-        "organisation-entity",
-        "entry-date",
-        "end-date",
-    }
-    entities = {}
-    with open(transformed_csv_path, "r", encoding="utf-8") as f:
-        for row in csv.DictReader(f):
-            entity = _normalise_entity_id(row.get("entity"))
-            field = row.get("field", "")
-            if not entity or field not in entity_fields:
-                continue
+    connection = duckdb.connect()
+    try:
+        rows = connection.execute(
+            """
+            SELECT entity, field, value
+            FROM read_csv(?, all_varchar = true, header = true)
+            """,
+            [transformed_csv_path],
+        ).fetchall()
+    finally:
+        connection.close()
 
-            entity_row = entities.setdefault(entity, {"entity": entity})
-            entity_row[field] = row.get("value", "")
+    entities = {}
+    for raw_entity, raw_field, value in rows:
+        entity = _normalise_entity_id(raw_entity)
+        field = str(raw_field or "").strip().lower()
+        if not entity or not field:
+            continue
+
+        entity_row = entities.setdefault(entity, {"entity": entity})
+        entity_row[field] = value or ""
 
     return list(entities.values())
+
+
+def _normalise_fingerprint_value(value) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalise_entity_fields(row: dict) -> dict:
+    return {
+        str(field).strip().lower(): value
+        for field, value in row.items()
+        if str(field).strip()
+    }
+
+
+def _non_spatial_comparison_fields(provision_rows: list[dict]) -> list[str]:
+    fields = {
+        str(field).strip().lower()
+        for row in provision_rows
+        for field in row
+        if field != "entity"
+        and str(field).strip().lower() not in NON_SPATIAL_EXCLUDED_FIELDS
+    }
+    return sorted(field for field in fields if field)
+
+
+def _quote_identifier(identifier: str) -> str:
+    return f'"{identifier.replace(chr(34), chr(34) * 2)}"'
+
+
+def _quote_literal(value: str) -> str:
+    return f"'{str(value).replace(chr(39), chr(39) * 2)}'"
+
+
+@contextmanager
+def _download_platform_dataset_parquet(dataset: str):
+    url = f"{DATASTORE_URL.rstrip('/')}/dataset/{quote(dataset)}.parquet"
+    file_descriptor, parquet_path = tempfile.mkstemp(suffix=".parquet")
+    os.close(file_descriptor)
+    response = None
+    try:
+        response = requests.get(url, timeout=120, stream=True)
+        response.raise_for_status()
+        with open(parquet_path, "wb") as parquet_file:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    parquet_file.write(chunk)
+        yield parquet_path
+    finally:
+        if response is not None:
+            response.close()
+        if os.path.exists(parquet_path):
+            os.unlink(parquet_path)
+
+
+def _match_platform_dataset_entities(
+    parquet_path: str,
+    provision_rows: list[dict],
+    comparison_fields: list[str],
+    organisation_provider: str = "",
+    organisation_entity: str = "",
+):
+    connection = duckdb.connect()
+    try:
+        platform_columns = [
+            row[0]
+            for row in connection.execute(
+                "DESCRIBE SELECT * FROM read_parquet(?)", [parquet_path]
+            ).fetchall()
+        ]
+        platform_columns_by_normalised_name = {
+            str(column).strip().lower(): column for column in platform_columns
+        }
+        if "entity" not in platform_columns_by_normalised_name:
+            return
+
+        platform_organisation_entity_column = platform_columns_by_normalised_name.get(
+            "organisation-entity"
+        ) or platform_columns_by_normalised_name.get("organisation_entity")
+        if organisation_entity and not platform_organisation_entity_column:
+            return
+        platform_organisation_column = platform_columns_by_normalised_name.get(
+            "organisation"
+        )
+        raw_platform_organisation_expression = (
+            f"cast(p.{_quote_identifier(platform_organisation_column)} AS VARCHAR)"
+            if platform_organisation_column
+            else "''"
+        )
+        platform_organisation_expression = (
+            _quote_literal(organisation_provider)
+            if organisation_provider
+            else f"coalesce(nullif({raw_platform_organisation_expression}, ''), '')"
+        )
+        platform_organisation_entity_expression = (
+            "trim(coalesce(cast("
+            f"p.{_quote_identifier(platform_organisation_entity_column)} AS VARCHAR), "
+            "''))"
+            if platform_organisation_entity_column
+            else "''"
+        )
+        comparison_column_names = [
+            f"comparison_{index}" for index in range(len(comparison_fields))
+        ]
+        definitions = ["new_entity VARCHAR"] + [
+            f"{_quote_identifier(column)} VARCHAR" for column in comparison_column_names
+        ]
+        connection.execute(f"CREATE TEMP TABLE provision ({', '.join(definitions)})")
+        connection.executemany(
+            f"INSERT INTO provision VALUES ({', '.join('?' for _ in definitions)})",
+            [
+                [str(row.get("entity", ""))]
+                + [
+                    _normalise_fingerprint_value(row.get(field, ""))
+                    for field in comparison_fields
+                ]
+                for row in provision_rows
+            ],
+        )
+
+        comparisons = []
+        for field, comparison_column in zip(comparison_fields, comparison_column_names):
+            platform_column = platform_columns_by_normalised_name.get(field)
+            if field == "organisation":
+                platform_expression = platform_organisation_expression
+            else:
+                platform_expression = (
+                    f"p.{_quote_identifier(platform_column)}"
+                    if platform_column
+                    else "''"
+                )
+            comparisons.append(
+                "lower(trim(coalesce(cast("
+                f"{platform_expression} AS VARCHAR), ''))) = "
+                f"r.{_quote_identifier(comparison_column)}"
+            )
+
+        entity_column = _quote_identifier(platform_columns_by_normalised_name["entity"])
+        platform_organisation_filter = ""
+        query_parameters = [parquet_path]
+        if organisation_entity and platform_organisation_entity_column:
+            platform_organisation_filter = (
+                f"AND {platform_organisation_entity_expression} = ?"
+            )
+            query_parameters.append(organisation_entity)
+        query = f"""
+            SELECT
+                p.*,
+                {platform_organisation_expression} AS __normalised_organisation,
+                r.new_entity AS __new_entity
+            FROM read_parquet(?) AS p
+            JOIN provision AS r ON {' AND '.join(comparisons)}
+            WHERE trim(coalesce(cast(p.{entity_column} AS VARCHAR), '')) <> ''
+              AND cast(p.{entity_column} AS VARCHAR) <> r.new_entity
+              {platform_organisation_filter}
+        """
+        cursor = connection.execute(query, query_parameters)
+        result_columns = [description[0] for description in cursor.description]
+        provision_by_id = {str(row.get("entity", "")): row for row in provision_rows}
+        for values in cursor.fetchall():
+            result = dict(zip(result_columns, values))
+            new_entity_id = str(result.pop("__new_entity", "") or "")
+            normalised_organisation = str(
+                result.pop("__normalised_organisation", "") or ""
+            )
+            if normalised_organisation:
+                result["organisation"] = normalised_organisation
+            new_entity = provision_by_id.get(new_entity_id)
+            if new_entity:
+                yield _normalise_entity_fields(result), new_entity
+    finally:
+        connection.close()
 
 
 def _organisation_row_for_provider(
@@ -210,8 +392,8 @@ def _build_candidate(
         or old_organisation_entity
         or match.get("organisation_entity_a", "")
     )
-    old_organisation = _organisation_identifier_for_entity(
-        organisation_index, old_organisation_entity
+    old_organisation = str(old_entity.get("organisation", "") or "") or (
+        _organisation_identifier_for_entity(organisation_index, old_organisation_entity)
     )
     evidence = [
         "point exact match" if spatial_field == "point" else f"geometry {match_type}"
@@ -256,7 +438,131 @@ def _build_candidate(
         ),
         "evidence": ", ".join(evidence),
         "name_similarity": similarity,
+        "old_fields": {
+            str(field): str(value or "")
+            for field, value in old_entity.items()
+            if field != "entity"
+        },
+        "new_fields": {
+            str(field): str(value or "")
+            for field, value in new_entity.items()
+            if field != "entity"
+        },
     }
+
+
+def _build_non_spatial_candidate(
+    *,
+    old_entity: dict,
+    new_entity: dict,
+    dataset: str,
+    redirect_lookups: dict,
+) -> dict:
+    old_entity_id = _normalise_entity_id(old_entity.get("entity"))
+    new_entity_id = _normalise_entity_id(new_entity.get("entity"))
+    candidate = {
+        "old_entity": old_entity_id,
+        "entity": new_entity_id,
+        "dataset": dataset,
+        "old_reference": str(old_entity.get("reference", "") or ""),
+        "new_reference": str(new_entity.get("reference", "") or ""),
+        "match_type": "all_fields_match",
+        "notes": REDIRECT_NOTE,
+        "old_name": str(old_entity.get("name", "") or ""),
+        "new_name": str(new_entity.get("name", "") or ""),
+        "old_entry_date": str(old_entity.get("entry-date", "") or ""),
+        "new_entry_date": str(new_entity.get("entry-date", "") or ""),
+        "old_end_date": str(old_entity.get("end-date", "") or ""),
+        "new_end_date": str(new_entity.get("end-date", "") or ""),
+        "old_organisation": str(old_entity.get("organisation", "") or ""),
+        "new_organisation": str(new_entity.get("organisation", "") or ""),
+        "old_organisation_entity": str(
+            old_entity.get("organisation-entity", "")
+            or old_entity.get("organisation_entity", "")
+            or ""
+        ),
+        "new_organisation_entity": str(
+            new_entity.get("organisation-entity", "")
+            or new_entity.get("organisation_entity", "")
+            or ""
+        ),
+        "evidence": "all comparable fields match",
+        "name_similarity": "",
+        "old_fields": {
+            str(field): str(value or "")
+            for field, value in old_entity.items()
+            if field != "entity"
+        },
+        "new_fields": {
+            str(field): str(value or "")
+            for field, value in new_entity.items()
+            if field != "entity"
+        },
+    }
+    existing_redirect = redirect_lookups.get(old_entity_id)
+    candidate["old_entity_redirects"] = (
+        [{"old-entity": old_entity_id, **existing_redirect}]
+        if existing_redirect
+        else []
+    )
+    return candidate
+
+
+def _find_non_spatial_candidates(
+    dataset: str,
+    provision_rows: list[dict],
+    redirect_lookups: dict,
+    download_platform_dataset_parquet,
+    organisation_provider="",
+    organisation_index=None,
+) -> list[dict]:
+    comparison_fields = _non_spatial_comparison_fields(provision_rows)
+    if not comparison_fields:
+        return []
+
+    candidates = []
+    seen = set()
+    organisation_entity = _resolve_organisation_entity(
+        organisation_index, organisation_provider
+    )
+    if organisation_provider and not organisation_entity:
+        return []
+    try:
+        with download_platform_dataset_parquet(dataset) as parquet_path:
+            matches = _match_platform_dataset_entities(
+                parquet_path,
+                provision_rows,
+                comparison_fields,
+                organisation_provider,
+                organisation_entity,
+            )
+            for platform_row, provision_row in matches:
+                old_entity_id = _normalise_entity_id(platform_row.get("entity"))
+                new_entity_id = _normalise_entity_id(provision_row.get("entity"))
+                key = (old_entity_id, new_entity_id)
+                if (
+                    not old_entity_id
+                    or not new_entity_id
+                    or key[0] == key[1]
+                    or key in seen
+                ):
+                    continue
+                seen.add(key)
+                candidates.append(
+                    _build_non_spatial_candidate(
+                        old_entity=platform_row,
+                        new_entity=provision_row,
+                        dataset=dataset,
+                        redirect_lookups=redirect_lookups,
+                    )
+                )
+    except Exception as err:
+        logger.exception(
+            "Failed to compare platform dataset %s for duplicates: %s", dataset, err
+        )
+        return []
+
+    return candidates
 
 
 def _entities_for_match(match: dict, provision_by_id: dict, platform_by_id: dict):
@@ -290,15 +596,25 @@ def find_duplicate_redirect_candidates(
     organisation_provider: str = "",
     organisation_index=None,
     fetch_platform_entities=_fetch_platform_entities,
+    download_platform_dataset_parquet=_download_platform_dataset_parquet,
 ) -> list[dict]:
-    if dataset != "conservation-area":
-        return []
-
-    if specification.get_dataset_typology(dataset) != "geography":
-        return []
-
     provision_rows = _read_provision_entities(transformed_csv_path)
     if not provision_rows:
+        return []
+
+    dataset_typology = specification.get_dataset_typology(dataset)
+    redirect_lookups = redirect_lookups or {}
+    if dataset_typology != "geography":
+        return _find_non_spatial_candidates(
+            dataset,
+            provision_rows,
+            redirect_lookups,
+            download_platform_dataset_parquet,
+            organisation_provider,
+            organisation_index,
+        )
+
+    if dataset != "conservation-area":
         return []
 
     organisation_entity = _resolve_organisation_entity(
@@ -318,8 +634,6 @@ def find_duplicate_redirect_candidates(
         _normalise_entity_id(row.get("entity")): row for row in platform_rows
     }
     combined_rows = platform_rows + provision_rows
-    redirect_lookups = redirect_lookups or {}
-
     matches = []
     for spatial_field in ("geometry", "point"):
         field_matches = _run_duplicate_check(combined_rows, spatial_field)

--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -61,6 +61,62 @@ def _filter_selected_entities(new_entities, excluded_references):
     ]
 
 
+def _index_duplicate_candidates(duplicate_candidates):
+    candidates_by_selection = {}
+    candidate_old_entities = set()
+    for candidate in duplicate_candidates:
+        reference = str(candidate.get("new_reference", "")).strip()
+        old_entity = str(candidate.get("old_entity", "")).strip()
+        entity = str(candidate.get("entity", "")).strip()
+        if old_entity:
+            candidate_old_entities.add(old_entity)
+        if reference and old_entity and entity:
+            candidates_by_selection.setdefault((reference, old_entity), []).append(
+                candidate
+            )
+    return candidates_by_selection, candidate_old_entities
+
+
+def _selected_old_entity_row(
+    redirect,
+    candidates_by_selection,
+    candidate_old_entities,
+    excluded_references,
+    organisation,
+):
+    status = str(redirect.get("status", "") or "301").strip()
+    if status not in REDIRECT_STATUSES:
+        status = "301"
+
+    reference = str(redirect.get("reference", "")).strip()
+    old_entity = str(redirect.get("old_entity_number", "")).strip()
+    if status == "410":
+        if old_entity not in candidate_old_entities:
+            return None
+        return _old_entity_row(
+            old_entity,
+            "",
+            notes=_prefix_old_entity_notes(
+                organisation, "retirement selected in Assign Entities"
+            ),
+            status=status,
+        )
+
+    if reference in excluded_references:
+        return None
+
+    candidates = candidates_by_selection.get((reference, old_entity), [])
+    if len(candidates) != 1:
+        return None
+    candidate = candidates[0]
+    return _old_entity_row(
+        old_entity,
+        candidate.get("entity"),
+        notes=_prefix_old_entity_notes(organisation, candidate.get("evidence", "")),
+        status=status,
+    )
+
+
 def _create_old_entity_redirects(
     selected_redirects,
     duplicate_candidates,
@@ -79,60 +135,19 @@ def _create_old_entity_redirects(
         return []
 
     excluded_references = _reference_set(excluded_references)
+    candidates_by_selection, candidate_old_entities = _index_duplicate_candidates(
+        duplicate_candidates
+    )
+
     old_entity_rows = []
     seen = set()
-    candidates_by_selection = {}
-    candidate_old_entities = set()
-    for candidate in duplicate_candidates:
-        key = (
-            str(candidate.get("new_reference", "")).strip(),
-            str(candidate.get("old_entity", "")).strip(),
-        )
-        if key[1]:
-            candidate_old_entities.add(key[1])
-        if all(key) and str(candidate.get("entity", "")).strip():
-            candidates_by_selection.setdefault(key, []).append(candidate)
-
     for redirect in selected_redirects:
-        status = str(redirect.get("status", "") or "301").strip()
-        if status not in REDIRECT_STATUSES:
-            status = "301"
-        reference = str(redirect.get("reference", "")).strip()
-        old_entity = str(redirect.get("old_entity_number", "")).strip()
-        if status == "410":
-            if not old_entity:
-                continue
-            if old_entity not in candidate_old_entities:
-                continue
-            row = _old_entity_row(
-                old_entity,
-                "",
-                notes=_prefix_old_entity_notes(
-                    organisation, "retirement selected in Assign Entities"
-                ),
-                status=status,
-            )
-            row_key = (row["old-entity"], row["entity"])
-            if row_key not in seen:
-                seen.add(row_key)
-                old_entity_rows.append(row)
-            continue
-
-        if reference in excluded_references:
-            continue
-
-        candidates = candidates_by_selection.get((reference, old_entity), [])
-        if len(candidates) != 1:
-            continue
-        candidate = candidates[0]
-        entity = str(candidate.get("entity", "")).strip()
-
-        notes = _prefix_old_entity_notes(organisation, candidate.get("evidence", ""))
-        row = _old_entity_row(
-            old_entity,
-            entity,
-            notes=notes,
-            status=status,
+        row = _selected_old_entity_row(
+            redirect,
+            candidates_by_selection,
+            candidate_old_entities,
+            excluded_references,
+            organisation,
         )
         if not row:
             continue

--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -16,6 +16,18 @@ from application.core.duplicates import find_duplicate_redirect_candidates
 
 logger = get_logger(__name__)
 
+REDIRECT_STATUSES = {"301", "410"}
+
+
+def _prefix_old_entity_notes(organisation, notes):
+    organisation = str(organisation or "").strip()
+    notes = str(notes or "").strip()
+    if not organisation:
+        return notes
+    if notes == organisation or notes.startswith(f"{organisation} "):
+        return notes
+    return " ".join(part for part in (organisation, notes) if part)
+
 
 def _reference_set(references):
     """Return normalised reference values from an optional request list."""
@@ -50,51 +62,77 @@ def _filter_selected_entities(new_entities, excluded_references):
 
 
 def _create_old_entity_redirects(
-    new_entities,
     selected_redirects,
+    duplicate_candidates,
     excluded_references=None,
-    duplicate_candidates=None,
+    organisation="",
 ):
     """
     Build old-entity rows from explicit redirect selections.
 
-    selected_redirects is a list of objects containing a new entity reference
-    and old entity number. Duplicate candidates provide the evidence note.
+    A 301 selection contains a target reference and old entity number. A 410
+    selection contains only the old entity number and status. Duplicate
+    candidates validate the action and provide the current redirect target.
     References excluded by excluded_references cannot be redirected.
     """
     if not selected_redirects:
         return []
 
-    selected_new_entities = _filter_selected_entities(new_entities, excluded_references)
-
+    excluded_references = _reference_set(excluded_references)
     old_entity_rows = []
     seen = set()
-    evidence_by_redirect = {
-        (
+    candidates_by_selection = {}
+    candidate_old_entities = set()
+    for candidate in duplicate_candidates:
+        key = (
             str(candidate.get("new_reference", "")).strip(),
             str(candidate.get("old_entity", "")).strip(),
-            str(candidate.get("entity", "")).strip(),
-        ): str(candidate.get("evidence", "") or "")
-        for candidate in duplicate_candidates or []
-    }
-
-    entity_by_reference = {
-        str(entity.get("reference", "")).strip(): str(entity.get("entity", "")).strip()
-        for entity in selected_new_entities
-    }
+        )
+        if key[1]:
+            candidate_old_entities.add(key[1])
+        if all(key) and str(candidate.get("entity", "")).strip():
+            candidates_by_selection.setdefault(key, []).append(candidate)
 
     for redirect in selected_redirects:
+        status = str(redirect.get("status", "") or "301").strip()
+        if status not in REDIRECT_STATUSES:
+            status = "301"
         reference = str(redirect.get("reference", "")).strip()
         old_entity = str(redirect.get("old_entity_number", "")).strip()
-        entity = entity_by_reference.get(reference, "")
-        if not old_entity or not entity:
+        if status == "410":
+            if not old_entity:
+                continue
+            if old_entity not in candidate_old_entities:
+                continue
+            row = _old_entity_row(
+                old_entity,
+                "",
+                notes=_prefix_old_entity_notes(
+                    organisation, "retirement selected in Assign Entities"
+                ),
+                status=status,
+            )
+            row_key = (row["old-entity"], row["entity"])
+            if row_key not in seen:
+                seen.add(row_key)
+                old_entity_rows.append(row)
             continue
 
-        notes = evidence_by_redirect.get((reference, old_entity, entity), "")
+        if reference in excluded_references:
+            continue
+
+        candidates = candidates_by_selection.get((reference, old_entity), [])
+        if len(candidates) != 1:
+            continue
+        candidate = candidates[0]
+        entity = str(candidate.get("entity", "")).strip()
+
+        notes = _prefix_old_entity_notes(organisation, candidate.get("evidence", ""))
         row = _old_entity_row(
             old_entity,
             entity,
             notes=notes,
+            status=status,
         )
         if not row:
             continue
@@ -108,17 +146,20 @@ def _create_old_entity_redirects(
     return old_entity_rows
 
 
-def _old_entity_row(old_entity, entity, notes=""):
-    """Return a valid old-entity redirect row, or None for incomplete ids."""
+def _old_entity_row(old_entity, entity, notes="", status="301"):
+    """Return a valid old-entity redirect or retirement row."""
     old_entity = str(old_entity or "").strip()
     entity = str(entity or "").strip()
-    if not old_entity or not entity:
+    status = str(status or "301").strip()
+    if status not in REDIRECT_STATUSES:
+        status = "301"
+    if not old_entity or (status == "301" and not entity):
         return None
 
     return {
         "old-entity": old_entity,
-        "status": "301",
-        "entity": entity,
+        "status": status,
+        "entity": "" if status == "410" else entity,
         "entry-date": date.today().isoformat(),
         "notes": str(notes or ""),
     }
@@ -143,7 +184,11 @@ def _should_auto_redirect(candidate):
     return match_type == "single_match" and _name_similarity_score(candidate) > 85
 
 
-def _create_auto_old_entity_redirects(duplicate_candidates, selected_entity_ids=None):
+def _create_auto_old_entity_redirects(
+    duplicate_candidates,
+    selected_entity_ids=None,
+    organisation="",
+):
     """
     Build old-entity rows for duplicate matches that meet the auto-redirect rules.
 
@@ -164,7 +209,7 @@ def _create_auto_old_entity_redirects(duplicate_candidates, selected_entity_ids=
         row = _old_entity_row(
             candidate.get("old_entity"),
             entity,
-            notes=candidate.get("evidence", ""),
+            notes=_prefix_old_entity_notes(organisation, candidate.get("evidence", "")),
         )
         if row:
             old_entity_rows.append(row)
@@ -692,13 +737,15 @@ def fetch_add_data_response(
         )
         old_entity_rows = _merge_old_entity_rows(
             _create_auto_old_entity_redirects(
-                duplicate_candidates, selected_entity_ids=selected_entity_ids
+                duplicate_candidates,
+                selected_entity_ids=selected_entity_ids,
+                organisation=organisations[0],
             ),
             _create_old_entity_redirects(
-                new_entities,
                 selected_redirects,
+                duplicate_candidates,
                 excluded_references,
-                duplicate_candidates=duplicate_candidates,
+                organisation=organisations[0],
             ),
         )
 

--- a/request-processor/src/application/core/pipeline.py
+++ b/request-processor/src/application/core/pipeline.py
@@ -63,24 +63,24 @@ def _filter_selected_entities(new_entities, excluded_references):
 
 def _index_duplicate_candidates(duplicate_candidates):
     candidates_by_selection = {}
-    candidate_old_entities = set()
+    candidates_by_old_entity = {}
     for candidate in duplicate_candidates:
         reference = str(candidate.get("new_reference", "")).strip()
         old_entity = str(candidate.get("old_entity", "")).strip()
         entity = str(candidate.get("entity", "")).strip()
         if old_entity:
-            candidate_old_entities.add(old_entity)
+            candidates_by_old_entity.setdefault(old_entity, []).append(candidate)
         if reference and old_entity and entity:
             candidates_by_selection.setdefault((reference, old_entity), []).append(
                 candidate
             )
-    return candidates_by_selection, candidate_old_entities
+    return candidates_by_selection, candidates_by_old_entity
 
 
 def _selected_old_entity_row(
     redirect,
     candidates_by_selection,
-    candidate_old_entities,
+    candidates_by_old_entity,
     excluded_references,
     organisation,
 ):
@@ -91,7 +91,13 @@ def _selected_old_entity_row(
     reference = str(redirect.get("reference", "")).strip()
     old_entity = str(redirect.get("old_entity_number", "")).strip()
     if status == "410":
-        if old_entity not in candidate_old_entities:
+        candidates = candidates_by_old_entity.get(old_entity, [])
+        if not candidates:
+            return None
+        if all(
+            str(candidate.get("new_reference", "")).strip() in excluded_references
+            for candidate in candidates
+        ):
             return None
         return _old_entity_row(
             old_entity,
@@ -135,7 +141,7 @@ def _create_old_entity_redirects(
         return []
 
     excluded_references = _reference_set(excluded_references)
-    candidates_by_selection, candidate_old_entities = _index_duplicate_candidates(
+    candidates_by_selection, candidates_by_old_entity = _index_duplicate_candidates(
         duplicate_candidates
     )
 
@@ -145,7 +151,7 @@ def _create_old_entity_redirects(
         row = _selected_old_entity_row(
             redirect,
             candidates_by_selection,
-            candidate_old_entities,
+            candidates_by_old_entity,
             excluded_references,
             organisation,
         )
@@ -233,15 +239,17 @@ def _create_auto_old_entity_redirects(
 
 
 def _merge_old_entity_rows(*row_groups):
-    """Merge old-entity row groups, keeping the first row for each old/new pair."""
+    """Merge rows by old entity, allowing a retirement to replace a redirect."""
     rows = []
-    seen = set()
+    row_indexes = {}
     for row_group in row_groups:
         for row in row_group:
-            key = (row.get("old-entity"), row.get("entity"))
-            if key in seen:
+            key = row.get("old-entity")
+            if key in row_indexes:
+                if row.get("status") == "410":
+                    rows[row_indexes[key]] = row
                 continue
-            seen.add(key)
+            row_indexes[key] = len(rows)
             rows.append(row)
     return rows
 
@@ -622,8 +630,8 @@ def _find_duplicate_candidates(
     """
     Find possible redirects for the transformed add-data output.
 
-    Duplicate analysis should not block add-data processing, so failures are
-    logged and returned as an empty candidate list.
+    Failures are logged and propagated so they cannot be mistaken for an empty
+    candidate list.
     """
     try:
         return find_duplicate_redirect_candidates(
@@ -636,7 +644,7 @@ def _find_duplicate_candidates(
         )
     except Exception as err:
         logger.exception("Duplicate analysis failed for dataset %s: %s", dataset, err)
-        return []
+        raise
 
 
 def fetch_add_data_response(

--- a/request-processor/src/application/core/workflow.py
+++ b/request-processor/src/application/core/workflow.py
@@ -660,8 +660,6 @@ def add_data_workflow(
             "transformed-csv": csv_to_json(output_path),
         }
 
-        logger.info(f"add data response is for id {request_id} : {response_data}")
-
     except Exception as e:
         logger.warning(
             f"An error occurred in add_data_workflow: {e} for request id {request_id}"

--- a/request-processor/src/tasks.py
+++ b/request-processor/src/tasks.py
@@ -656,9 +656,13 @@ def save_response_to_db(request_id, response_data):
                     )
 
                 elif "message" in response_data:
-                    error = CustomException(response_data)
+                    if "errMsg" in response_data:
+                        error_detail = dict(response_data)
+                        error_detail["errMsg"] = error_detail.pop("message")
+                    else:
+                        error_detail = CustomException(response_data).detail
                     new_response = models.Response(
-                        request_id=request_id, error=error.detail
+                        request_id=request_id, error=error_detail
                     )
                     session.add(new_response)
                     session.commit()
@@ -690,7 +694,15 @@ def _fetch_resource(resource_dir, url, endpoint_parameters=None):
         )
         log["fetch-status"] = fetch_status.name
         if plugin is None:
-            content_type = log.get("response-headers", {}).get("content-type")
+            response_headers = log.get("response-headers", {})
+            content_type = next(
+                (
+                    value
+                    for key, value in response_headers.items()
+                    if key.lower() == "content-type"
+                ),
+                None,
+            )
         if fetch_status == FetchStatus.OK:
             log["plugin"] = plugin
             try:

--- a/request-processor/src/tasks.py
+++ b/request-processor/src/tasks.py
@@ -437,7 +437,6 @@ def add_data_task(request: Dict, directories=None):
             )
             if "plugin" in log:
                 response["plugin"] = log["plugin"]
-            logger.info(f"response is : {response}")
             save_response_to_db(request_schema.id, response)
         else:
             save_response_to_db(request_schema.id, log)

--- a/request-processor/tests/unit/src/application/core/test_pipeline.py
+++ b/request-processor/tests/unit/src/application/core/test_pipeline.py
@@ -549,14 +549,14 @@ def test_fetch_add_data_response_includes_selected_old_entity_redirects(
             "status": "301",
             "entity": "1000002",
             "entry-date": date.today().isoformat(),
-            "notes": "geometry complete_match, name similarity 100%",
+            "notes": "test-org geometry complete_match, name similarity 100%",
         },
         {
             "old-entity": "900001",
             "status": "301",
             "entity": "1000002",
             "entry-date": date.today().isoformat(),
-            "notes": "geometry single_match, name similarity 85%",
+            "notes": "test-org geometry single_match, name similarity 85%",
         },
     ]
     assert result["new-entities"] == [
@@ -816,13 +816,7 @@ def test_create_entity_organisation_uses_selected_entity_subset(tmp_path):
 
 
 def test_create_old_entity_redirects_from_selected_redirects():
-    new_entities = [
-        {"entity": "1000001", "reference": "REF001", "organisation": "test-org"},
-        {"entity": "1000002", "reference": "REF002", "organisation": "test-org"},
-    ]
-
     result = _create_old_entity_redirects(
-        new_entities,
         [{"reference": "REF002", "old_entity_number": "900001"}],
         duplicate_candidates=[
             {
@@ -832,6 +826,7 @@ def test_create_old_entity_redirects_from_selected_redirects():
                 "evidence": "geometry single_match, name similarity 85%",
             }
         ],
+        organisation="local-authority:MAI",
     )
 
     assert result == [
@@ -840,19 +835,161 @@ def test_create_old_entity_redirects_from_selected_redirects():
             "status": "301",
             "entity": "1000002",
             "entry-date": date.today().isoformat(),
-            "notes": "geometry single_match, name similarity 85%",
+            "notes": "local-authority:MAI geometry single_match, name similarity 85%",
         }
     ]
 
 
-def test_create_old_entity_redirects_ignores_redirects_for_excluded_references():
-    new_entities = [
-        {"entity": "1000001", "reference": "REF001", "organisation": "test-org"},
-        {"entity": "1000002", "reference": "REF002", "organisation": "test-org"},
+def test_create_old_entity_redirects_applies_selected_status():
+    result = _create_old_entity_redirects(
+        [
+            {
+                "old_entity_number": "900001",
+                "status": "410",
+            }
+        ],
+        duplicate_candidates=[
+            {
+                "old_entity": "900001",
+                "entity": "1000002",
+                "new_reference": "REF002",
+                "match_type": "all_fields_match",
+                "evidence": "all comparable fields match",
+            }
+        ],
+        organisation="local-authority:MAI",
+    )
+
+    assert result[0]["status"] == "410"
+    assert result[0]["entity"] == ""
+    assert result[0]["notes"] == (
+        "local-authority:MAI retirement selected in Assign Entities"
+    )
+
+
+def test_create_old_entity_redirects_allows_existing_candidate_target():
+    result = _create_old_entity_redirects(
+        [
+            {
+                "old_entity_number": "7001056210",
+                "status": "410",
+            }
+        ],
+        duplicate_candidates=[
+            {
+                "old_entity": "7001056210",
+                "entity": "7001067890",
+                "new_reference": "TPO 20/90b",
+                "evidence": "all comparable fields match",
+            }
+        ],
+        organisation="local-authority:CAS",
+    )
+
+    assert result == [
+        {
+            "old-entity": "7001056210",
+            "status": "410",
+            "entity": "",
+            "entry-date": date.today().isoformat(),
+            "notes": "local-authority:CAS retirement selected in Assign Entities",
+        }
     ]
 
+
+def test_create_old_entity_redirects_resolves_current_target_from_selection():
     result = _create_old_entity_redirects(
-        new_entities,
+        [
+            {
+                "reference": "TPO 20/90b",
+                "old_entity_number": "7001056210",
+                "status": "301",
+            }
+        ],
+        duplicate_candidates=[
+            {
+                "old_entity": "7001056210",
+                "entity": "7001067890",
+                "new_reference": "TPO 20/90b",
+            }
+        ],
+    )
+
+    assert result == [
+        {
+            "old-entity": "7001056210",
+            "status": "301",
+            "entity": "7001067890",
+            "entry-date": date.today().isoformat(),
+            "notes": "",
+        }
+    ]
+
+
+def test_create_old_entity_redirects_rejects_changed_target_when_candidates_ambiguous():
+    result = _create_old_entity_redirects(
+        [
+            {
+                "reference": "TPO 20/90b",
+                "old_entity_number": "7001056210",
+                "status": "301",
+            }
+        ],
+        duplicate_candidates=[
+            {
+                "old_entity": "7001056210",
+                "entity": "7001067890",
+                "new_reference": "TPO 20/90b",
+            },
+            {
+                "old_entity": "7001056210",
+                "entity": "7001067891",
+                "new_reference": "TPO 20/90b",
+            },
+        ],
+    )
+
+    assert result == []
+
+
+def test_create_old_entity_retirement_rejects_unmatched_old_entity():
+    result = _create_old_entity_redirects(
+        [{"old_entity_number": "9999999999", "status": "410"}],
+        duplicate_candidates=[
+            {
+                "old_entity": "7001056210",
+                "entity": "7001067890",
+                "new_reference": "TPO 20/90b",
+            }
+        ],
+    )
+
+    assert result == []
+
+
+def test_create_old_entity_redirects_defaults_invalid_status_to_301():
+    result = _create_old_entity_redirects(
+        [
+            {
+                "reference": "REF002",
+                "old_entity_number": "900001",
+                "status": "302",
+            }
+        ],
+        duplicate_candidates=[
+            {
+                "old_entity": "900001",
+                "entity": "1000002",
+                "new_reference": "REF002",
+            }
+        ],
+    )
+
+    assert result[0]["status"] == "301"
+
+
+def test_create_old_entity_redirects_ignores_redirects_for_excluded_references():
+    result = _create_old_entity_redirects(
         [{"reference": "REF001", "old_entity_number": "900001"}],
         excluded_references=["REF001"],
         duplicate_candidates=[
@@ -879,6 +1016,7 @@ def test_create_auto_old_entity_redirects_for_complete_matches():
                 "old_entity_redirects": [],
             }
         ],
+        organisation="local-authority:MAI",
     )
 
     assert result == [
@@ -887,9 +1025,24 @@ def test_create_auto_old_entity_redirects_for_complete_matches():
             "status": "301",
             "entity": "1000001",
             "entry-date": date.today().isoformat(),
-            "notes": "geometry complete_match",
+            "notes": "local-authority:MAI geometry complete_match",
         }
     ]
+
+
+def test_create_auto_old_entity_redirects_requires_review_for_all_fields_match():
+    result = _create_auto_old_entity_redirects(
+        [
+            {
+                "old_entity": "900001",
+                "entity": "1000001",
+                "match_type": "all_fields_match",
+                "old_entity_redirects": [],
+            }
+        ]
+    )
+
+    assert result == []
 
 
 def test_create_auto_old_entity_redirects_for_single_matches_above_85_percent():
@@ -953,20 +1106,11 @@ def test_create_auto_old_entity_redirects_ignores_existing_redirects_and_unselec
 def test_create_old_entity_redirects_returns_empty_when_selection_empty_or_null(
     selected_redirects,
 ):
-    new_entities = [
-        {"entity": "1000001", "reference": "REF001", "organisation": "test-org"},
-    ]
-
-    assert _create_old_entity_redirects(new_entities, selected_redirects) == []
+    assert _create_old_entity_redirects(selected_redirects, []) == []
 
 
 def test_create_old_entity_redirects_ignores_unassigned_or_invalid_redirects():
-    new_entities = [
-        {"entity": "1000001", "reference": "REF001", "organisation": "test-org"},
-    ]
-
     result = _create_old_entity_redirects(
-        new_entities,
         [
             {"reference": "REF001"},
             {"old_entity_number": "900001"},

--- a/request-processor/tests/unit/src/application/core/test_pipeline.py
+++ b/request-processor/tests/unit/src/application/core/test_pipeline.py
@@ -14,6 +14,7 @@ from src.application.core.pipeline import (
     _create_entity_organisation,
     _format_task_summary,
     _find_duplicate_candidates,
+    _merge_old_entity_rows,
     run_task_pipeline,
 )
 
@@ -705,6 +706,23 @@ def test_find_duplicate_candidates_passes_redirect_lookups(monkeypatch, tmp_path
     assert calls["redirect_lookups"] == {"100": {"entity": "300", "status": "301"}}
 
 
+def test_find_duplicate_candidates_propagates_analysis_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.application.core.pipeline.find_duplicate_redirect_candidates",
+        MagicMock(side_effect=RuntimeError("comparison failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="comparison failed"):
+        _find_duplicate_candidates(
+            dataset="tree-preservation-order",
+            specification=MagicMock(),
+            output_path=str(tmp_path / "transformed.csv"),
+            redirect_lookups={},
+            organisation_provider="local-authority:STH",
+            organisation_index=MagicMock(),
+        )
+
+
 def test_get_entities_breakdown_success():
     """Test converting entities to breakdown format"""
     new_entities = [
@@ -881,6 +899,13 @@ def test_create_old_entity_redirects_allows_existing_candidate_target():
                 "entity": "7001067890",
                 "new_reference": "TPO 20/90b",
                 "evidence": "all comparable fields match",
+                "old_entity_redirects": [
+                    {
+                        "old-entity": "7001056210",
+                        "entity": "7001067890",
+                        "status": "301",
+                    }
+                ],
             }
         ],
         organisation="local-authority:CAS",
@@ -1002,6 +1027,39 @@ def test_create_old_entity_redirects_ignores_redirects_for_excluded_references()
     )
 
     assert result == []
+
+
+def test_create_old_entity_retirement_ignores_excluded_candidate_reference():
+    result = _create_old_entity_redirects(
+        [{"old_entity_number": "900001", "status": "410"}],
+        excluded_references=["REF001"],
+        duplicate_candidates=[
+            {
+                "old_entity": "900001",
+                "entity": "1000001",
+                "new_reference": "REF001",
+            }
+        ],
+    )
+
+    assert result == []
+
+
+def test_merge_old_entity_rows_manual_retirement_replaces_auto_redirect():
+    automatic_redirect = {
+        "old-entity": "900001",
+        "status": "301",
+        "entity": "1000001",
+    }
+    manual_retirement = {
+        "old-entity": "900001",
+        "status": "410",
+        "entity": "",
+    }
+
+    assert _merge_old_entity_rows([automatic_redirect], [manual_retirement]) == [
+        manual_retirement
+    ]
 
 
 def test_create_auto_old_entity_redirects_for_complete_matches():

--- a/request-processor/tests/unit/src/test_duplicates.py
+++ b/request-processor/tests/unit/src/test_duplicates.py
@@ -1,8 +1,13 @@
 import csv
 import importlib
+import os
 import sqlite3
 import sys
 import types
+from contextlib import contextmanager
+
+import duckdb
+import requests
 
 from application.core import duplicates
 
@@ -66,6 +71,92 @@ def _write_transformed_csv(path):
         )
         writer.writeheader()
         writer.writerows(rows)
+
+
+def _write_non_spatial_transformed_csv(path):
+    rows = []
+    for entity, reference, name, category, entry_date in (
+        ("200", "new-ref", "  Main Hall ", "Community", "2026-01-01"),
+        ("201", "different-ref", "Other Hall", "Education", "2026-01-01"),
+    ):
+        for field, value in (
+            ("reference", reference),
+            ("name", name),
+            ("category", category),
+            ("entry-date", entry_date),
+            ("notes", "resource-only notes"),
+            ("description", "resource-only description"),
+        ):
+            rows.append(
+                {
+                    "entry-number": entity,
+                    "entity": entity,
+                    "field": field,
+                    "value": value,
+                }
+            )
+
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["entry-number", "entity", "field", "value"]
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_non_spatial_transformed_csv_with_organisation(path):
+    rows = []
+    for field, value in (
+        ("reference", "new-ref"),
+        ("name", "Main Hall"),
+        ("category", "Community"),
+        ("entry-date", "2026-01-01"),
+        ("organisation", "local-authority:STH"),
+        ("organisation-entity", "resource-only-value"),
+    ):
+        rows.append(
+            {
+                "entry-number": "200",
+                "entity": "200",
+                "field": field,
+                "value": value,
+            }
+        )
+
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["entry-number", "entity", "field", "value"]
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+@contextmanager
+def _existing_parquet(path):
+    yield str(path)
+
+
+def _write_platform_parquet(path, rows):
+    csv_path = path.with_suffix(".source.csv")
+    fieldnames = list(dict.fromkeys(field for row in rows for field in row))
+    with open(csv_path, "w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    escaped_parquet_path = str(path).replace("'", "''")
+    connection = duckdb.connect()
+    try:
+        connection.execute(
+            f"""
+            COPY (
+                SELECT * FROM read_csv(?, all_varchar = true, header = true)
+            ) TO '{escaped_parquet_path}' (FORMAT PARQUET)
+            """,
+            [str(csv_path)],
+        )
+    finally:
+        connection.close()
 
 
 def test_duplicate_candidates_are_provision_entities_against_existing_platform(
@@ -351,9 +442,31 @@ def test_duplicate_candidates_skip_non_conservation_area(tmp_path, monkeypatch):
     assert candidates == []
 
 
-def test_duplicate_candidates_skip_non_geography(tmp_path, monkeypatch):
+def test_non_spatial_candidates_match_all_comparable_fields(tmp_path, monkeypatch):
     transformed_path = tmp_path / "transformed.csv"
-    _write_transformed_csv(transformed_path)
+    _write_non_spatial_transformed_csv(transformed_path)
+    platform_path = tmp_path / "platform.parquet"
+    _write_platform_parquet(
+        platform_path,
+        [
+            {
+                " Entity ": "100",
+                "Reference": "old-ref",
+                " Name ": "main hall",
+                "CATEGORY": " community ",
+                "entry-date": "2020-01-01",
+                "notes": "platform-only metadata",
+            },
+            {
+                " Entity ": "101",
+                "Reference": "old-other",
+                " Name ": "Other Hall",
+                "CATEGORY": "Different",
+                "entry-date": "2020-01-01",
+                "notes": "",
+            },
+        ],
+    )
     monkeypatch.setattr(
         duplicates,
         "_run_duplicate_check",
@@ -361,14 +474,183 @@ def test_duplicate_candidates_skip_non_geography(tmp_path, monkeypatch):
     )
 
     candidates = duplicates.find_duplicate_redirect_candidates(
-        dataset="article-4-direction",
+        dataset="tree-preservation-order",
+        specification=FakeSpecification(typology="legal-instrument"),
+        transformed_csv_path=str(transformed_path),
+        redirect_lookups={"100": {"entity": "300", "status": "301"}},
+        download_platform_dataset_parquet=lambda dataset: _existing_parquet(
+            platform_path
+        ),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["old_entity"] == "100"
+    assert candidates[0]["entity"] == "200"
+    assert candidates[0]["old_reference"] == "old-ref"
+    assert candidates[0]["new_reference"] == "new-ref"
+    assert candidates[0]["match_type"] == "all_fields_match"
+    assert candidates[0]["evidence"] == "all comparable fields match"
+    assert candidates[0]["old_fields"]["category"] == " community "
+    assert candidates[0]["new_fields"]["category"] == "Community"
+    assert candidates[0]["old_entity_redirects"] == [
+        {"old-entity": "100", "entity": "300", "status": "301"}
+    ]
+
+
+def test_non_spatial_candidates_emit_each_old_new_pair_and_skip_same_entity(tmp_path):
+    transformed_path = tmp_path / "transformed.csv"
+    _write_non_spatial_transformed_csv(transformed_path)
+    platform_path = tmp_path / "platform.parquet"
+    _write_platform_parquet(
+        platform_path,
+        [
+            {
+                "entity": "100",
+                "reference": "old-a",
+                "name": "Main Hall",
+                "category": "Community",
+            },
+            {
+                "entity": "101",
+                "reference": "old-b",
+                "name": "Main Hall",
+                "category": "Community",
+            },
+            {
+                "entity": "200",
+                "reference": "same-entity",
+                "name": "Main Hall",
+                "category": "Community",
+            },
+        ],
+    )
+
+    candidates = duplicates.find_duplicate_redirect_candidates(
+        dataset="tree-preservation-order",
+        specification=FakeSpecification(typology="legal-instrument"),
+        transformed_csv_path=str(transformed_path),
+        download_platform_dataset_parquet=lambda dataset: _existing_parquet(
+            platform_path
+        ),
+    )
+
+    assert sorted((row["old_entity"], row["entity"]) for row in candidates) == [
+        ("100", "200"),
+        ("101", "200"),
+    ]
+
+
+def test_non_spatial_candidates_resolve_platform_organisation_entity(tmp_path):
+    transformed_path = tmp_path / "transformed.csv"
+    _write_non_spatial_transformed_csv_with_organisation(transformed_path)
+    platform_path = tmp_path / "platform.parquet"
+    _write_platform_parquet(
+        platform_path,
+        [
+            {
+                "entity": "100",
+                "reference": "old-ref",
+                "name": "Main Hall",
+                "category": "Community",
+                "entry-date": "2020-01-01",
+                "organisation": "",
+                "organisation-entity": "318",
+            },
+            {
+                "entity": "101",
+                "reference": "other-org",
+                "name": "Main Hall",
+                "category": "Community",
+                "entry-date": "2020-01-01",
+                "organisation": "",
+                "organisation-entity": "999",
+            },
+        ],
+    )
+
+    candidates = duplicates.find_duplicate_redirect_candidates(
+        dataset="tree-preservation-order",
         specification=FakeSpecification(typology="legal-instrument"),
         transformed_csv_path=str(transformed_path),
         organisation_provider="local-authority:STH",
         organisation_index=FakeOrganisationIndex(),
-        fetch_platform_entities=lambda dataset, organisation_entity: [
-            {"entity": "100"}
-        ],
+        download_platform_dataset_parquet=lambda dataset: _existing_parquet(
+            platform_path
+        ),
+    )
+
+    assert [(row["old_entity"], row["entity"]) for row in candidates] == [
+        ("100", "200")
+    ]
+    assert candidates[0]["old_organisation"] == "local-authority:STH"
+    assert candidates[0]["old_organisation_entity"] == "318"
+    assert candidates[0]["old_fields"]["organisation"] == "local-authority:STH"
+
+
+def test_non_spatial_candidate_download_failure_returns_empty(tmp_path):
+    transformed_path = tmp_path / "transformed.csv"
+    _write_non_spatial_transformed_csv(transformed_path)
+
+    @contextmanager
+    def fail_fetch(dataset):
+        raise requests.RequestException("unavailable")
+        yield
+
+    candidates = duplicates.find_duplicate_redirect_candidates(
+        dataset="tree-preservation-order",
+        specification=FakeSpecification(typology="legal-instrument"),
+        transformed_csv_path=str(transformed_path),
+        download_platform_dataset_parquet=fail_fetch,
     )
 
     assert candidates == []
+
+
+def test_download_platform_dataset_parquet_streams_configured_file(
+    monkeypatch, tmp_path
+):
+    calls = []
+    source_path = tmp_path / "source.parquet"
+    _write_platform_parquet(source_path, [{"entity": "100", "name": "Main Hall"}])
+    parquet_bytes = source_path.read_bytes()
+
+    class FakeResponse:
+        status_code = 200
+        headers = {"Content-Length": str(len(parquet_bytes))}
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size):
+            assert chunk_size == 1024 * 1024
+            yield parquet_bytes
+
+        def close(self):
+            calls.append("closed")
+
+    def fake_get(url, timeout, stream):
+        calls.append((url, timeout, stream))
+        return FakeResponse()
+
+    monkeypatch.setattr(duplicates.requests, "get", fake_get)
+
+    with duplicates._download_platform_dataset_parquet("test dataset") as path:
+        downloaded_path = path
+        connection = duckdb.connect()
+        try:
+            rows = connection.execute(
+                "SELECT entity, name FROM read_parquet(?)", [path]
+            ).fetchall()
+        finally:
+            connection.close()
+
+    assert rows == [("100", "Main Hall")]
+    assert not os.path.exists(downloaded_path)
+    assert calls == [
+        (
+            "https://files.planning.data.gov.uk/dataset/test%20dataset.parquet",
+            120,
+            True,
+        ),
+        "closed",
+    ]

--- a/request-processor/tests/unit/src/test_duplicates.py
+++ b/request-processor/tests/unit/src/test_duplicates.py
@@ -82,6 +82,7 @@ def _write_non_spatial_transformed_csv(path):
     ):
         for field, value in (
             ("reference", reference),
+            ("conservation-area", "CA-MAI-02"),
             ("name", name),
             ("category", category),
             ("entry-date", entry_date),
@@ -158,6 +159,26 @@ def _write_platform_parquet(path, rows):
         )
     finally:
         connection.close()
+
+
+def test_non_spatial_comparison_fields_use_whitelist():
+    fields = duplicates._non_spatial_comparison_fields(
+        [
+            {
+                "entity": "200",
+                "name": "Main Hall",
+                "start-date": "2026-01-01",
+                "doc-url": "https://example.com/doc",
+                "document-url": "https://example.com/document",
+                "documentation-url": "https://example.com/documentation",
+                "category": "Community",
+                "conservation-area": "CA-MAI-02",
+                "reference": "new-ref",
+            }
+        ]
+    )
+
+    assert fields == ["doc-url", "document-url", "name", "start-date"]
 
 
 def test_duplicate_candidates_are_provision_entities_against_existing_platform(
@@ -453,6 +474,7 @@ def test_non_spatial_candidates_match_all_comparable_fields(tmp_path, monkeypatc
             {
                 " Entity ": "100",
                 "Reference": "old-ref",
+                "conservation-area": "CA04",
                 " Name ": "main hall",
                 "CATEGORY": " community ",
                 "entry_date": "2020-01-01",
@@ -461,7 +483,7 @@ def test_non_spatial_candidates_match_all_comparable_fields(tmp_path, monkeypatc
             {
                 " Entity ": "101",
                 "Reference": "old-other",
-                " Name ": "Other Hall",
+                " Name ": "Different Hall",
                 "CATEGORY": "Different",
                 "entry-date": "2020-01-01",
                 "notes": "",
@@ -495,6 +517,8 @@ def test_non_spatial_candidates_match_all_comparable_fields(tmp_path, monkeypatc
     assert candidates[0]["new_entry_date"] == "2026-01-01"
     assert candidates[0]["old_fields"]["category"] == " community "
     assert candidates[0]["new_fields"]["category"] == "Community"
+    assert candidates[0]["old_fields"]["conservation-area"] == "CA04"
+    assert candidates[0]["new_fields"]["conservation-area"] == "CA-MAI-02"
     assert candidates[0]["old_entity_redirects"] == [
         {"old-entity": "100", "entity": "300", "status": "301"}
     ]

--- a/request-processor/tests/unit/src/test_duplicates.py
+++ b/request-processor/tests/unit/src/test_duplicates.py
@@ -7,6 +7,7 @@ import types
 from contextlib import contextmanager
 
 import duckdb
+import pytest
 import requests
 
 from application.core import duplicates
@@ -454,7 +455,7 @@ def test_non_spatial_candidates_match_all_comparable_fields(tmp_path, monkeypatc
                 "Reference": "old-ref",
                 " Name ": "main hall",
                 "CATEGORY": " community ",
-                "entry-date": "2020-01-01",
+                "entry_date": "2020-01-01",
                 "notes": "platform-only metadata",
             },
             {
@@ -490,6 +491,8 @@ def test_non_spatial_candidates_match_all_comparable_fields(tmp_path, monkeypatc
     assert candidates[0]["new_reference"] == "new-ref"
     assert candidates[0]["match_type"] == "all_fields_match"
     assert candidates[0]["evidence"] == "all comparable fields match"
+    assert candidates[0]["old_entry_date"] == "2020-01-01"
+    assert candidates[0]["new_entry_date"] == "2026-01-01"
     assert candidates[0]["old_fields"]["category"] == " community "
     assert candidates[0]["new_fields"]["category"] == "Community"
     assert candidates[0]["old_entity_redirects"] == [
@@ -587,7 +590,7 @@ def test_non_spatial_candidates_resolve_platform_organisation_entity(tmp_path):
     assert candidates[0]["old_fields"]["organisation"] == "local-authority:STH"
 
 
-def test_non_spatial_candidate_download_failure_returns_empty(tmp_path):
+def test_non_spatial_candidate_download_failure_is_propagated(tmp_path):
     transformed_path = tmp_path / "transformed.csv"
     _write_non_spatial_transformed_csv(transformed_path)
 
@@ -596,14 +599,13 @@ def test_non_spatial_candidate_download_failure_returns_empty(tmp_path):
         raise requests.RequestException("unavailable")
         yield
 
-    candidates = duplicates.find_duplicate_redirect_candidates(
-        dataset="tree-preservation-order",
-        specification=FakeSpecification(typology="legal-instrument"),
-        transformed_csv_path=str(transformed_path),
-        download_platform_dataset_parquet=fail_fetch,
-    )
-
-    assert candidates == []
+    with pytest.raises(requests.RequestException, match="unavailable"):
+        duplicates.find_duplicate_redirect_candidates(
+            dataset="tree-preservation-order",
+            specification=FakeSpecification(typology="legal-instrument"),
+            transformed_csv_path=str(transformed_path),
+            download_platform_dataset_parquet=fail_fetch,
+        )
 
 
 def test_download_platform_dataset_parquet_streams_configured_file(
@@ -648,7 +650,7 @@ def test_download_platform_dataset_parquet_streams_configured_file(
     assert not os.path.exists(downloaded_path)
     assert calls == [
         (
-            "https://files.planning.data.gov.uk/dataset/test%20dataset.parquet",
+            f"{duplicates.DATASTORE_URL.rstrip('/')}/dataset/test%20dataset.parquet",
             120,
             True,
         ),

--- a/request-processor/tests/unit/src/test_tasks.py
+++ b/request-processor/tests/unit/src/test_tasks.py
@@ -3,7 +3,7 @@ import database
 import pytest
 import json
 from src import tasks
-from src.tasks import save_response_to_db, check_dataurl
+from src.tasks import save_response_to_db, check_dataurl, _fetch_resource
 from request_model import models, schemas
 from unittest.mock import MagicMock
 from application.exceptions.customExceptions import CustomException
@@ -47,6 +47,34 @@ from application.exceptions.customExceptions import CustomException
             ),
             {"message": "Test message", "status": "404"},
             ["errCode", "errMsg", "errTime", "errType"],
+        ),
+        (
+            "formatted_check_url_error",
+            schemas.RequestTypeEnum.check_url,
+            schemas.CheckUrlParams(
+                collection="local-plan",
+                dataset="plan-timetable",
+                url="https://example.com/explore",
+            ),
+            {
+                "message": "The selected file must be a CSV, GeoJSON, GML or GeoPackage file",
+                "errMsg": "All fetch attempts failed",
+                "errCode": None,
+                "errType": "User Error",
+                "endpointUrl": "https://example.com/explore",
+                "fetchStatus": "FAILED",
+                "exceptionType": "JSONDecodeError",
+                "contentType": "text/html; charset=utf-8",
+                "plugin": "arcgis",
+            },
+            [
+                "errMsg",
+                "endpointUrl",
+                "fetchStatus",
+                "exceptionType",
+                "contentType",
+                "plugin",
+            ],
         ),
     ],
 )
@@ -93,6 +121,14 @@ def test_save_response_to_db(
 
         for key in expected_keys:
             assert key in data, f"{key} should be present in data"
+
+        if test_name == "formatted_check_url_error":
+            assert data["errMsg"] == (
+                "The selected file must be a CSV, GeoJSON, GML or GeoPackage file"
+            )
+            assert data["endpointUrl"] == "https://example.com/explore"
+            assert data["exceptionType"] == "JSONDecodeError"
+            assert "message" not in data
 
         if test_name == "success_check_file":
             # Check if response_details table has details
@@ -171,6 +207,47 @@ def test_save_add_data_response_details_matches_integer_issue_entry_numbers(db):
     assert details[1].detail["issue_logs"] == [
         {"entry-number": 2, "issue-type": "missing field"}
     ]
+
+
+def test_fetch_resource_preserves_html_content_type_case_insensitively(
+    monkeypatch, tmp_path
+):
+    url = "https://example.com/explore"
+
+    class FakeCollector:
+        def __init__(self, resource_dir):
+            self.resource_dir = resource_dir
+
+        def fetch(self, url, plugin, parameters, refill_todays_logs):
+            if plugin is None:
+                return tasks.FetchStatus.FAILED, {
+                    "endpoint-url": url,
+                    "status": "200",
+                    "response-headers": {"Content-Type": "text/html; charset=utf-8"},
+                }
+            return tasks.FetchStatus.FAILED, {
+                "endpoint-url": url,
+                "exception": "JSONDecodeError",
+            }
+
+    monkeypatch.setattr(tasks, "Collector", FakeCollector)
+
+    with pytest.raises(CustomException) as exception:
+        _fetch_resource(tmp_path, url)
+
+    assert exception.value.detail == {
+        "errCode": None,
+        "errType": "User Error",
+        "errMsg": "All fetch attempts failed",
+        "errMsgDetail": None,
+        "errTime": exception.value.detail["errTime"],
+        "endpointUrl": url,
+        "entryDate": None,
+        "fetchStatus": "FAILED",
+        "exceptionType": "JSONDecodeError",
+        "contentType": "text/html; charset=utf-8",
+        "plugin": "arcgis",
+    }
 
 
 def test_download_resource_uses_datastore_url(monkeypatch, tmp_path):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds duplicate detection and old-entity redirect handling for non-spatial datasets.

The request processor now:

- Compares provision entities against the published dataset Parquet file using normalised, non-metadata fields.
- Scopes duplicate matching to the relevant organisation where applicable.
- Returns the old and new field values as evidence for duplicate candidates.
- Supports reviewed `301` redirects and `410` retirements.
- Validates selected redirects against the generated duplicate candidates and rejects ambiguous or unmatched selections.
- Includes the organisation in generated old-entity notes.
- Preserves the existing spatial duplicate workflow for conservation areas.
- Removes verbose add-data response logging.

## Related Tickets & Documents

- Ticket: 2709 

## QA Instructions, Screenshots, Recordings


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None identified.

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate detection now supports non-geographical datasets, with improved matching and candidate handling.
  * Added support for creating 301 redirects and 410 retirements, including organisation details in notes.

* **Bug Fixes**
  * Improved validation for ambiguous, unmatched, excluded or invalid redirect selections.
  * Spatial duplicate results now retain complete entity information and resolve organisation details more reliably.
  * Improved error reporting and handling for failed dataset downloads and resource requests.

* **Improvements**
  * Automatic redirects now provide clearer organisation context and avoid unsuitable duplicate matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->